### PR TITLE
Add gcp auditlog extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # resource-policy-evaluation-library
 
-rpe-lib is made up of `Policy Engines (rpe.engines.Engine)` and `Resources (rpe.resources.Resource)`.
+rpe-lib is made up of `Policy Engines (rpe.engines.Engine)`, `Resources (rpe.resources.Resource)`, and `Extractors (rpe.resources.Extractor)`.
 
 `Resources` produce details about the current state of a given type of resource. A resource can be just about anything, but the initial goal of the project was to support Google Cloud Platform (GCP) resources. The implemention is intentionally generic to allow support for other resource types
 
 `Policy Engines` evaluate `Resources` against their configured policies. Given a resource, they can return a list of `Evaluations (rpe.policy.Evaluation)` indicating the name of each policy that applies to the resource (by resource type), and whether or not the resource is compliant. `Resource` also define a `remediate()` function, that should be able to take a dictionary description of how to manipulate a resource to make it compliant.
+
+`Extractors` parse structured data and return a list of resources, and optionally metadata about the data source.
 
 As an example, for GCP resources, the `remediate()` function expects details about what method to call in the Google REST API for the given resource, and what parameters to pass. So for a Google Cloud Storage Bucket, a policy that enforces bucket versioning could define remediation as a call to the buckets `patch()` method with the appropriate arguments to enable versioning.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 120
+skip-string-normalization = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ google-api-python-client-helpers>=1.2.6
 google-api-python-client==2.0.2
 jmespath
 tenacity
+python-dateutil

--- a/rpe/exceptions.py
+++ b/rpe/exceptions.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from urllib.error import URLError
 
 from googleapiclient.errors import HttpError
-from urllib.error import URLError
 
 
 def is_retryable_exception(err):
@@ -55,4 +55,8 @@ class UnsupportedRemediationSpec(Exception):
 
 
 class InvalidRemediationSpecStep(Exception):
+    pass
+
+
+class ExtractorException(Exception):
     pass

--- a/rpe/extractors/__init__.py
+++ b/rpe/extractors/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2021 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class Extractor:
+    '''Extract resoruces from stuctured data, such as log messages'''
+
+    pass

--- a/rpe/extractors/gcp_auditlogs.py
+++ b/rpe/extractors/gcp_auditlogs.py
@@ -1,0 +1,421 @@
+# Copyright 2021 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+import dateutil.parser
+import jmespath
+
+from rpe.exceptions import ExtractorException
+from rpe.extractors import Extractor
+from rpe.extractors.models import ExtractedMetadata, ExtractedResources
+from rpe.resources.gcp import GoogleAPIResource
+
+
+@dataclass
+class OperationEnum(str, Enum):
+    create = 'create'
+    read = 'read'
+    update = 'update'
+    delete = 'delete'
+
+
+@dataclass
+class GCPAuditLogMetadata(ExtractedMetadata):
+    id: str
+    timestamp: datetime
+    principal: Optional[str]
+    method_name: Optional[str]
+    operation: Optional[OperationEnum]
+
+
+class GCPAuditLog(Extractor):
+    @classmethod
+    def extract(cls, log_message):
+        # Attempt to load it like a pubsub message, without requiring the pubsub client to be installed
+        if not isinstance(log_message, dict):
+            message_data = json.loads(log_message.data)
+        else:
+            message_data = log_message
+
+        if not cls.is_audit_log(message_data):
+            raise ExtractorException('Not an audit log')
+
+        metadata = cls.get_metadata(message_data)
+        resources = cls.get_resources(message_data)
+
+        return ExtractedResources(
+            resources=resources,
+            metadata=metadata,
+        )
+
+    @classmethod
+    def is_audit_log(cls, message_data):
+
+        log_type = jmespath.search('protoPayload."@type"', message_data)
+        log_name = message_data.get('logName', '')
+
+        # normal activity logs have logName in this form:
+        #  projects/<p>/logs/cloudaudit.googleapis.com%2Factivity
+        # data access logs have a logName field that looks like:
+        #  projects/<p>/logs/cloudaudit.googleapis.com%2Fdata_access
+
+        return all(
+            [
+                log_type == 'type.googleapis.com/google.cloud.audit.AuditLog',
+                log_name.split('/')[-1].startswith('cloudaudit.googleapis.com'),
+            ]
+        )
+
+    @classmethod
+    def get_metadata(cls, message_data):
+
+        method_name = jmespath.search('protoPayload.methodName', message_data)
+        insert_id = message_data.get('insertId')
+
+        log_timestamp = message_data.get('timestamp')
+        timestamp = dateutil.parser.parse(log_timestamp)
+
+        principal_email = jmespath.search('protoPayload.authenticationInfo.principalEmail', message_data)
+
+        operation = cls.get_operation_type(method_name)
+
+        return GCPAuditLogMetadata(
+            id=insert_id,
+            timestamp=timestamp,
+            method_name=method_name,
+            operation=operation,
+            principal=principal_email,
+        )
+
+    @classmethod
+    def get_operation_type(cls, method_name):
+
+        last = method_name.split('.')[-1].lower()
+        # For batch methods, look for the verb after the word 'batch'
+        if last.startswith('batch'):
+            last = last[5:]
+
+        read_prefixes = ('get', 'list')
+        if last.startswith(read_prefixes):
+            return 'read'
+
+        update_prefixes = (
+            'update',
+            'patch',
+            'set',
+            'debug',
+            'enable',
+            'disable',
+            'expand',
+            'deactivate',
+            'activate',
+            'switch',
+        )
+
+        if last.startswith(update_prefixes):
+            return 'update'
+
+        create_prefixes = (
+            'create',
+            'insert',
+        )
+
+        if last.startswith(create_prefixes):
+            return 'create'
+
+        delete_prefixes = ('delete',)
+        if last.startswith(delete_prefixes):
+            return 'delete'
+
+        return None
+
+    @classmethod
+    def get_resources(cls, message):
+
+        resources = []
+
+        res_type = jmespath.search('resource.type', message)
+        if res_type is None:
+            return resources
+
+        # just shortening the many calls to jmespath throughout this function
+        # this sub-function saves us from passing the message each time
+        def prop(exp):
+            return jmespath.search(exp, message)
+
+        def add_resource():
+            r = resource_data.copy()
+            res = GoogleAPIResource.from_resource_data(**r)
+            resources.append(res)
+
+        method_name = prop('protoPayload.methodName')
+
+        if res_type == 'cloudsql_database' and method_name.startswith('cloudsql.instances'):
+
+            resource_data = {
+                'resource_type': 'sqladmin.googleapis.com/Instance',
+                # CloudSQL logs are inconsistent. See https://issuetracker.google.com/issues/137629452
+                'name': (
+                    prop('resource.labels.database_id').split(':')[-1]
+                    or prop('protoPayload.request.body.name')
+                    or prop('protoPayload.request.resource.instanceName.instanceId')
+                ),
+                'location': prop('resource.labels.region'),
+                'project_id': prop('resource.labels.project_id'),
+            }
+            add_resource()
+
+        elif res_type == "gcs_bucket" and method_name.startswith(('storage.buckets', 'storage.setIamPermissions')):
+            resource_data = {
+                'resource_type': 'storage.googleapis.com/Bucket',
+                'name': prop("resource.labels.bucket_name"),
+                'location': prop("resource.labels.location"),
+                'project_id': prop("resource.labels.project_id"),
+            }
+            add_resource()
+
+        elif res_type == "bigquery_dataset":
+            if "DatasetService" in method_name or 'etIamPolicy' in method_name:
+                resource_data = {
+                    'resource_type': 'bigquery.googleapis.com/Dataset',
+                    'name': prop("resource.labels.dataset_id"),
+                    'project_id': prop("resource.labels.project_id"),
+                }
+                add_resource()
+
+        elif res_type == "project" and 'etIamPolicy' in method_name:
+            resource_data = {
+                'resource_type': 'cloudresourcemanager.googleapis.com/Project',
+                'name': prop("resource.labels.project_id"),
+                'project_id': prop("resource.labels.project_id"),
+            }
+            add_resource()
+
+        elif res_type == "pubsub_subscription" and 'etIamPolicy' in method_name:
+            resource_data = {
+                'resource_type': 'pubsub.googleapis.com/Subscription',
+                'name': prop("resource.labels.subscription_id").split('/')[-1],
+                'project_id': prop("resource.labels.project_id"),
+            }
+            add_resource()
+
+        elif res_type == "pubsub_topic" and 'etIamPolicy' in method_name:
+            resource_data = {
+                'resource_type': 'pubsub.googleapis.com/Topic',
+                'name': prop("resource.labels.topic_id").split('/')[-1],
+                'project_id': prop("resource.labels.project_id"),
+            }
+            add_resource()
+
+        elif res_type == 'audited_resource' and (
+            'EnableService' in method_name or 'DisableService' in method_name or 'ctivateService' in method_name
+        ):
+
+            resource_data = {
+                'resource_type': 'serviceusage.googleapis.com/Service',
+                'project_id': prop("resource.labels.project_id"),
+            }
+
+            # Check if multiple services were included in the request
+            # The Google Cloud Console generates (De)activate calls that logs a different format so we check both
+            # known formats
+            services = prop('protoPayload.request.serviceIds') or prop('protoPayload.request.serviceNames')
+            if services:
+                for s in services:
+                    resource_data['name'] = s
+                    add_resource()
+            else:
+                resource_data['name'] = prop("protoPayload.resourceName").split('/')[-1]
+                add_resource()
+
+        elif res_type == 'audited_resource' and 'DeactivateServices' in method_name:
+            resource_data = {
+                'resource_type': 'serviceusage.googleapis.com/Service',
+                'name': prop("resource.labels.service"),
+                'project_id': prop("resource.labels.project_id"),
+            }
+            add_resource()
+
+        elif res_type == "gce_network":
+            resource_data = {
+                'resource_type': 'compute.googleapis.com/Network',
+                'name': prop("protoPayload.resourceName").split('/')[-1],
+                'project_id': prop("resource.labels.project_id"),
+            }
+            add_resource()
+
+        elif res_type == "gce_subnetwork":
+            resource_data = {
+                'resource_type': 'compute.googleapis.com/Subnetwork',
+                'name': prop("resource.labels.subnetwork_name"),
+                'project_id': prop("resource.labels.project_id"),
+                'location': prop("resource.labels.location"),
+            }
+            add_resource()
+
+        elif res_type == "gce_firewall_rule":
+            resource_data = {
+                'resource_type': 'compute.googleapis.com/Firewall',
+                'name': prop("protoPayload.resourceName").split('/')[-1],
+                'project_id': prop("resource.labels.project_id"),
+            }
+            add_resource()
+
+        elif res_type == "gae_app" and 'DebugInstance' in method_name:
+            instance_data = prop("protoPayload.resourceName").split('/')
+            resource_data = {
+                'resource_type': 'appengine.googleapis.com/Instance',
+                'name': instance_data[-1],
+                'app': instance_data[1],
+                'service': instance_data[3],
+                'version': instance_data[5],
+            }
+            add_resource()
+
+        elif res_type == "gce_instance":
+
+            instance_name = prop('protoPayload.resourceName').split('/')[-1]
+
+            resource_data = {
+                'resource_type': 'compute.googleapis.com/Instance',
+                'name': instance_name,
+                'location': prop("resource.labels.zone"),
+                'project_id': prop("resource.labels.project_id"),
+            }
+
+            # Logs are sent for some resources that are hidden by the compute API. We've found that some of these
+            # start with reserved prefixes. If the instance looks like a hidden resource, stop looking for
+            # resources and return immediately
+            compute_reserved_prefixes = ('aef-', 'aet-')
+            if resource_data['name'].startswith(compute_reserved_prefixes):
+                return resources
+
+            add_resource()
+
+            # Also add disk resources since theres not a separate log message for these
+            disks = prop('protoPayload.request.disks') or []
+
+            for disk in disks:
+
+                # The name of the disk is complicated. If the diskName is set in initParams use that
+                # If not AND its the boot disk, use the instance name
+                # Otherwise use the device name
+
+                disk_name = jmespath.search('initializeParams.diskName', disk)
+                device_name = jmespath.search('deviceName', disk)
+                boot = jmespath.search('boot', disk)
+
+                actual_disk_name = disk_name or (boot and instance_name) or device_name
+
+                resource_data = {
+                    'resource_type': 'compute.googleapis.com/Disk',
+                    'name': actual_disk_name,
+                    'location': prop("resource.labels.zone"),
+                    'project_id': prop("resource.labels.project_id"),
+                }
+
+                add_resource()
+
+        elif res_type == "cloud_function":
+            resource_data = {
+                'name': prop("resource.labels.function_name"),
+                'project_id': prop("resource.labels.project_id"),
+                'location': prop("resource.labels.region"),
+                'resource_type': 'cloudfunctions.googleapis.com/CloudFunction',
+            }
+
+            add_resource()
+
+        elif res_type == "cloud_dataproc_cluster":
+            resource_data = {
+                'resource_type': 'dataproc.googleapis.com/Cluster',
+                'project_id': prop("resource.labels.project_id"),
+                'name': prop("resource.labels.cluster_name"),
+                'location': prop("resource.labels.region"),
+            }
+            add_resource()
+
+        elif res_type == "gke_cluster":
+            resource_data = {
+                'resource_type': 'container.googleapis.com/Cluster',
+                'name': prop("resource.labels.cluster_name"),
+                'project_id': prop("resource.labels.project_id"),
+                'location': prop("resource.labels.location"),
+            }
+            add_resource()
+
+            # add node pool resources for eval on new cluster creation
+            if "create" in method_name.lower() and prop("protoPayload.request.cluster.nodePools") is not None:
+                resource_data['resource_type'] = 'container.googleapis.com/NodePool'
+                resource_data['cluster'] = prop("resource.labels.cluster_name")
+                for pool in prop("protoPayload.request.cluster.nodePools"):
+                    resource_data['name'] = pool.get('name')
+                    add_resource()
+
+        elif res_type == "gke_nodepool":
+            resource_data = {
+                'resource_type': 'container.googleapis.com/NodePool',
+                'cluster': prop("resource.labels.cluster_name"),
+                'name': prop("resource.labels.nodepool_name"),
+                'project_id': prop("resource.labels.project_id"),
+                'location': prop("resource.labels.location"),
+            }
+            add_resource()
+
+        elif res_type == "audited_resource" and 'BigtableInstanceAdmin' in method_name:
+            resource_data = {
+                'name': prop("protoPayload.resourceName").split('/')[-1],
+                'project_id': prop("resource.labels.project_id"),
+            }
+
+            resource_data['resource_type'] = 'bigtableadmin.googleapis.com/Instance'
+            add_resource()
+
+        elif res_type == "dataflow_step" and 'create' in method_name:
+            # The endpoint expects the job id instead of name
+            resource_data = {
+                'name': prop("protoPayload.request.job_id"),
+                'project_id': prop("resource.labels.project_id"),
+                'location': prop("resource.labels.region"),
+            }
+
+            resource_data['resource_type'] = 'dataflow.googleapis.com/Job'
+            add_resource()
+
+        elif res_type == "audited_resource" and 'CloudRedis' in method_name:
+            resource_data = {
+                'name': prop("protoPayload.resourceName").split('/')[-1],
+                'project_id': prop("resource.labels.project_id"),
+                'location': prop("protoPayload.resourceLocation.currentLocations")[0],
+            }
+
+            resource_data['resource_type'] = 'redis.googleapis.com/Instance'
+            add_resource()
+
+        elif res_type == "audited_resource" and prop('resource.labels.service') == 'datafusion.googleapis.com':
+            name_bits = prop('protoPayload.resourceName').split('/')
+            resource_data = {
+                'name': name_bits[5],
+                'project_id': name_bits[1],
+                'location': name_bits[3],
+                'resource_type': 'datafusion.googleapis.com/Instance',
+            }
+            add_resource()
+
+        return resources

--- a/rpe/extractors/models.py
+++ b/rpe/extractors/models.py
@@ -1,0 +1,31 @@
+# Copyright 2021 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from rpe.resources.base import Resource
+
+
+@dataclass
+class ExtractedMetadata:
+    pass
+
+
+@dataclass
+class ExtractedResources:
+    resources: List[Resource]
+    metadata: ExtractedMetadata

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'google-api-python-client-helpers',
         'jmespath',
         'tenacity',
+        'python-dateutil'
     ],
     packages=[
         'rpe',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
     author="Joe Ceresini",
-    url="https://github.com/forseti-security/resource-policy-evaluation-library",
+    url="https://github.com/cleardataeng/resource-policy-evaluation-library",
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
     install_requires=[

--- a/tests/data/app-engine-debug.json
+++ b/tests/data/app-engine-debug.json
@@ -1,0 +1,38 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "example@email.com"
+    },
+    "requestMetadata": {
+      "requestAttributes": {},
+      "destinationAttributes": {}
+    },
+    "serviceName": "appengine.googleapis.com",
+    "methodName": "google.appengine.v1.Instances.DebugInstance",
+    "resourceName": "apps/my_project/services/default/versions/test-instance/instances/aef-default-test-instance",
+    "resourceLocation": {
+      "currentLocations": [
+        "us-central1"
+      ]
+    }
+  },
+  "insertId": "509n2xdgx0k",
+  "resource": {
+    "type": "gae_app",
+    "labels": {
+      "module_id": "default",
+      "project_id": "my_project",
+      "version_id": "20190805t143926"
+    }
+  },
+  "timestamp": "1970-01-01T00:00:00.000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my_project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "ed13b6c2-f6b0-4291-9b9f-fb122bea5c25",
+    "producer": "appengine.googleapis.com/admin",
+    "last": true
+  },
+  "receiveTimestamp": "1970-01-01T00:00:00.000Z"
+}

--- a/tests/data/bigtable-set-iam-policy.json
+++ b/tests/data/bigtable-set-iam-policy.json
@@ -1,0 +1,67 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "example@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0.0.0.0",
+      "callerSuppliedUserAgent": "curl",
+      "requestAttributes": {
+        "time": "2000-01-01T00:00:01.339010394Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "bigtableadmin.googleapis.com",
+    "methodName": "google.bigtable.admin.v2.BigtableInstanceAdmin.SetIamPolicy",
+    "authorizationInfo": [
+      {
+        "resource": "projects/example-project/instances/example-instance",
+        "permission": "bigtable.instances.setIamPolicy",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "projects/example-project/instances/example-instance",
+    "request": {
+      "resource": "projects/example-project/instances/example-instance",
+      "@type": "type.googleapis.com/google.iam.v1.SetIamPolicyRequest",
+      "policy": {
+        "bindings": [
+          {
+            "role": "roles/bigtable.viewer",
+            "members": [
+              "group:allUsers"
+            ]
+          }
+        ]
+      }
+    },
+    "response": {
+      "etag": "11111",
+      "bindings": [
+        {
+          "role": "roles/bigtable.viewer",
+          "members": [
+            "group:allUsers"
+          ]
+        }
+      ],
+      "@type": "type.googleapis.com/google.iam.v1.Policy"
+    }
+  },
+  "insertId": "11111",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "method": "google.bigtable.admin.v2.BigtableInstanceAdmin.SetIamPolicy",
+      "project_id": "example-project",
+      "service": "bigtableadmin.googleapis.com"
+    }
+  },
+  "timestamp": "2000-01-01T00:00:01.333165743Z",
+  "severity": "NOTICE",
+  "logName": "projects/example-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "receiveTimestamp": "2000-01-01T00:00:01.363595014Z"
+}

--- a/tests/data/bq-ds-set-iam-policy.json
+++ b/tests/data/bq-ds-set-iam-policy.json
@@ -1,0 +1,67 @@
+{
+    "insertId": "hrutgge6gxqm",
+    "logName": "projects/fake-project/logs/cloudaudit.googleapis.com%2Factivity",
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {
+            "principalEmail": "user@example.com"
+        },
+        "authorizationInfo": [
+            {
+                "granted": true,
+                "permission": "bigquery.datasets.update",
+                "resource": "projects/fake-project/datasets/wooo"
+            }
+        ],
+        "metadata": {
+            "@type": "type.googleapis.com/google.cloud.audit.BigQueryAuditMetadata",
+            "datasetChange": {
+                "dataset": {
+                    "acl": {
+                        "policy": {
+                            "bindings": [
+                                {
+                                    "members": [
+                                        "projectEditor:fake-project"
+                                    ],
+                                    "role": "roles/bigquery.dataEditor"
+                                },
+                                {
+                                    "members": [
+                                        "projectOwner:fake-project",
+                                        "user:user@example.com"
+                                    ],
+                                    "role": "roles/bigquery.dataOwner"
+                                },
+                                {
+                                    "members": [
+                                        "allUsers",
+                                        "projectViewer:fake-project"
+                                    ],
+                                    "role": "roles/bigquery.dataViewer"
+                                }
+                            ],
+                            "etag": "BwWFK46Dgyk="
+                        }
+                    },
+                    "datasetName": "projects/fake-project/datasets/wooo"
+                }
+            }
+        },
+        "methodName": "google.iam.v1.IAMPolicy.SetIamPolicy",
+        "requestMetadata": {},
+        "resourceName": "projects/fake-project/datasets/wooo",
+        "serviceName": "bigquery.googleapis.com",
+        "status": {}
+    },
+    "receiveTimestamp": "2019-03-28T18:16:45.294057957Z",
+    "resource": {
+        "labels": {
+            "dataset_id": "wooo",
+            "project_id": "fake-project"
+        },
+        "type": "bigquery_dataset"
+    },
+    "severity": "NOTICE",
+    "timestamp": "2019-03-28T18:16:44.642Z"
+}

--- a/tests/data/cloudfunctions-set-iam-policy.json
+++ b/tests/data/cloudfunctions-set-iam-policy.json
@@ -1,0 +1,78 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "some.user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0.0.0.0",
+      "callerSuppliedUserAgent": "curl",
+      "requestAttributes": {
+        "time": "2000-01-01T00:00:01.689Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "cloudfunctions.googleapis.com",
+    "methodName": "google.cloud.functions.v1.CloudFunctionsService.SetIamPolicy",
+    "authorizationInfo": [
+      {
+        "permission": "cloudfunctions.functions.setIamPolicy",
+        "granted": true,
+        "resourceAttributes": {}
+      },
+      {
+        "resource": "projects/example-project/locations/us-central1/functions/example_function",
+        "permission": "cloudfunctions.functions.setIamPolicy",
+        "granted": true,
+        "resourceAttributes": {}
+      },
+      {
+        "permission": "cloudfunctions.functions.setIamPolicy",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "projects/example-project/locations/us-central1/functions/example_function",
+    "request": {
+      "policy": {
+        "etag": "BwWP3fXnMuQ=",
+        "bindings": [
+          {
+            "members": [
+              "allUsers"
+            ],
+            "role": "roles/cloudfunctions.invoker"
+          }
+        ]
+      },
+      "resource": "projects/example-project/locations/us-central1/functions/example_function",
+      "@type": "type.googleapis.com/google.iam.v1.SetIamPolicyRequest"
+    },
+    "response": {
+      "bindings": [
+        {
+          "members": [
+            "allUsers"
+          ],
+          "role": "roles/cloudfunctions.invoker"
+        }
+      ],
+      "@type": "type.googleapis.com/google.iam.v1.Policy",
+      "etag": "BwWP6bTHbeg="
+    }
+  },
+  "insertId": "g3ygy1c248",
+  "resource": {
+    "type": "cloud_function",
+    "labels": {
+      "project_id": "example-project",
+      "region": "us-central1",
+      "function_name": "example_function"
+    }
+  },
+  "timestamp": "2000-01-01T00:00:01.497Z",
+  "severity": "NOTICE",
+  "logName": "projects/example-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "receiveTimestamp": "2000-01-01T11:20:07.411040465Z"
+}

--- a/tests/data/cloudsql-protoPayload.request.body.json
+++ b/tests/data/cloudsql-protoPayload.request.body.json
@@ -1,0 +1,70 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "user@domain.com"
+    },
+    "requestMetadata": {
+      "callerIp": "000.0.000.0",
+      "requestAttributes": {
+        "time": "1970-01-01T00:00:00.000Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "cloudsql.googleapis.com",
+    "methodName": "cloudsql.instances.create",
+    "authorizationInfo": [
+      {
+        "resource": "projects/my-project",
+        "permission": "cloudsql.instances.create",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "projects/my-project",
+    "request": {
+      "@type": "type.googleapis.com/google.cloud.sql.v0beta0.SqlInstancesInsertRequest",
+      "body": {
+        "settings": {
+          "tier": "db-n0-standard-0"
+        },
+        "name": "test-instance"
+      },
+      "project": "my-project"
+    },
+    "response": {
+      "name": "0000b000-0d0b-00b0-0000-c0bf00000000",
+      "targetId": "test-instance",
+      "@type": "type.googleapis.com/google.cloud.sql.v0beta0.SqlOperation",
+      "instanceUid": "0-ae00ea00-ba0b-000e-000a-e0f0000a0a00",
+      "insertTime": "1970-01-01T00:00:00.000Z",
+      "user": "user@domain.com",
+      "targetProject": "my-project",
+      "selfLink": "https://content.googleapis.com/sql/v0beta0/projects/my-project/operations/0000b000-0d0b-00b0-0000-c0bf00000000",
+      "targetLink": "https://content.googleapis.com/sql/v0beta0/projects/my-project/instances/test-instance",
+      "operationType": "CREATE",
+      "kind": "sql#operation",
+      "status": "PENDING"
+    }
+  },
+  "insertId": "-rqgf0kenyyg0",
+  "resource": {
+    "type": "cloudsql_database",
+    "labels": {
+      "project_id": "my-project",
+      "database_id": "",
+      "region": ""
+    }
+  },
+  "timestamp": "1970-01-01T00:00:00.000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "0000b000-0d0b-00b0-0000-c0bf00000000",
+    "producer": "cloudsql.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+}

--- a/tests/data/cloudsql-protoPayload.request.resource.instanceName.instanceId.json
+++ b/tests/data/cloudsql-protoPayload.request.resource.instanceName.instanceId.json
@@ -1,0 +1,78 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "user@domain.com"
+    },
+    "requestMetadata": {
+      "callerIp": "00.00.000.000",
+      "requestAttributes": {
+        "time": "1970-01-01T00:00:00.000Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "cloudsql.googleapis.com",
+    "methodName": "cloudsql.instances.create",
+    "authorizationInfo": [
+      {
+        "resource": "instances/my-project:test-instance",
+        "permission": "cloudsql.instances.create",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "instances/my-project:test-instance",
+    "request": {
+      "clientIp": "00.00.000.000",
+      "resource": {
+        "instanceName": {
+          "fullProjectId": "my-project",
+          "instanceId": "test-instance"
+        },
+        "region": "us-central0",
+        "instanceType": "CLOUDSQL_INSTANCE",
+        "databaseVersion": "MYSQL_0_0",
+        "backendType": "SECOND_GEN",
+        "settings": {
+          "backupConfig": {
+            "binaryLogEnabled": true,
+            "enabled": true,
+            "specification": "every day 00:00"
+          },
+          "ipConfiguration": {
+            "enabled": true
+          },
+          "maintenanceWindow": {},
+          "storageAutoResize": true,
+          "pricingPlan": "PER_USAGE",
+          "storageAutoResizeLimit": "0",
+          "tier": "db-n0-standard-0",
+          "activationPolicy": "ALWAYS",
+          "locationPreference": {},
+          "dataDiskSizeGb": "00",
+          "dataDiskType": "PD_SSD"
+        }
+      },
+      "@type": "type.googleapis.com/cloudsql.admin.InstancesInsertRequest"
+    }
+  },
+  "insertId": "l00ll0eltq0g",
+  "resource": {
+    "type": "cloudsql_database",
+    "labels": {
+      "project_id": "my-project",
+      "database_id": "",
+      "region": "us-central"
+    }
+  },
+  "timestamp": "1970-01-01T00:00:00.000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "000cc00c-0000-00f0-0e00-00c0c000ddf0",
+    "producer": "cloudsql.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+}

--- a/tests/data/cloudsql-resource.labels.json
+++ b/tests/data/cloudsql-resource.labels.json
@@ -1,0 +1,63 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "user@domain.com"
+    },
+    "requestMetadata": {
+      "callerIp": "00.00.000.000",
+      "requestAttributes": {
+        "time": "1970-01-01T00:00:00.000Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "cloudsql.googleapis.com",
+    "methodName": "cloudsql.instances.create",
+    "authorizationInfo": [
+      {
+        "resource": "instances/my-project:test-instance",
+        "permission": "cloudsql.instances.create",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "instances/my-project:test-instance",
+    "response": {
+      "@type": "type.googleapis.com/cloudsql.admin.InstancesInsertResponse",
+      "operation": {
+        "insertTime": "0000000000000",
+        "operationName": {
+          "operationId": "000cc00c-0000-00f0-0e00-00c0c000ddf0",
+          "instanceName": {
+            "fullProjectId": "my-project",
+            "instanceId": "test-instance"
+          }
+        },
+        "state": "PENDING",
+        "operationType": "CREATE",
+        "userEmailAddress": "user@domain.com"
+      },
+      "operationId": "000cc00c-0000-00f0-0e00-00c0c000ddf0"
+    }
+  },
+  "insertId": "xxxxx",
+  "resource": {
+    "type": "cloudsql_database",
+    "labels": {
+      "project_id": "my-project",
+      "database_id": "my-project:test-instance",
+      "region": "us-central"
+    }
+  },
+  "timestamp": "1970-01-01T00:00:00.000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "-0000000000000000000",
+    "producer": "cloudsql.googleapis.com",
+    "last": true
+  },
+  "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+}

--- a/tests/data/compute-firewalls-enable-logs-policy.json
+++ b/tests/data/compute-firewalls-enable-logs-policy.json
@@ -1,0 +1,99 @@
+ {
+   "protoPayload": {
+     "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+     "authenticationInfo": {
+       "principalEmail": "user@domain.com"
+     },
+     "requestMetadata": {
+       "callerIp": "00.00.000.000",
+       "callerSuppliedUserAgent": "user_agent",
+       "requestAttributes": {
+         "time": "1970-01-01T00:00:00.000Z",
+         "reason": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+         "auth": {}
+       },
+       "destinationAttributes": {}
+     },
+     "serviceName": "compute.googleapis.com",
+     "methodName": "v1.compute.firewalls.insert",
+     "authorizationInfo": [
+       {
+         "permission": "compute.firewalls.create",
+         "granted": true,
+         "resourceAttributes": {
+           "service": "compute",
+           "name": "projects/my-project/global/firewalls/test-firewall",
+           "type": "compute.firewalls"
+         }
+       },
+       {
+         "permission": "compute.networks.updatePolicy",
+         "granted": true,
+         "resourceAttributes": {
+           "service": "compute",
+           "name": "projects/my-project/global/networks/default",
+           "type": "compute.networks"
+         }
+       }
+     ],
+     "resourceName": "projects/my-project/global/firewalls/test-firewall",
+     "request": {
+       "direction": "INGRESS",
+       "alloweds": [
+         {
+           "IPProtocol": "tcp",
+           "ports": [
+             "8888"
+           ]
+         }
+       ],
+       "targetTags": [
+         "test"
+       ],
+       "name": "test-firewall",
+       "@type": "type.googleapis.com/compute.firewalls.insert",
+       "priority": "1000",
+       "network": "projects/my-project/global/networks/default",
+       "sourceRanges": [
+         "0.0.0.0/0"
+       ]
+     },
+     "response": {
+       "@type": "type.googleapis.com/operation",
+       "startTime": "1970-01-01T00:00:00.000-00:00",
+       "progress": "0",
+       "insertTime": "1970-01-01T00:00:00.000-00:00",
+       "user": "user@domain.com",
+       "selfLink": "https://www.googleapis.com/compute/v1/projects/my-project/global/operations/operation-0000000000000-0000000000000-00000000-00000000",
+       "targetLink": "https://www.googleapis.com/compute/v1/projects/my-project/global/firewalls/test-firewall",
+       "operationType": "insert",
+       "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/my-project/global/operations/000000000000000000",
+       "status": "RUNNING",
+       "name": "operation-0000000000000-0000000000000-00000000-00000000",
+       "targetId": "0000000000000000000",
+       "id": "000000000000000000"
+     },
+     "resourceLocation": {
+       "currentLocations": [
+         "global"
+       ]
+     }
+   },
+   "insertId": "00000000000",
+   "resource": {
+     "type": "gce_firewall_rule",
+     "labels": {
+       "firewall_rule_id": "0000000000000000123",
+       "project_id": "my-project"
+     }
+   },
+   "timestamp": "1970-01-01T00:00:00.000Z",
+   "severity": "NOTICE",
+   "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+   "operation": {
+     "id": "operation-0000000000000-0000000000000-00000000-00000000",
+     "producer": "type.googleapis.com",
+     "first": true
+   },
+   "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+ }

--- a/tests/data/compute-hardened-images.json
+++ b/tests/data/compute-hardened-images.json
@@ -1,0 +1,240 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "service-000000000000@gcp-sa-notebooks.iam.gserviceaccount.com"
+    },
+    "requestMetadata": {
+      "callerIp": "2002:a17:90a:4285:b029:14f:f0e0:f4ce",
+      "callerSuppliedUserAgent": "google-api-go-client/0.5",
+      "requestAttributes": {
+        "time": "2021-04-15T17:43:10.114288Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.instances.insert",
+    "authorizationInfo": [
+      {
+        "permission": "compute.instances.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/my-project/zones/us-west1-b/instances/my-instance",
+          "type": "compute.instances"
+        }
+      },
+      {
+        "permission": "compute.disks.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/my-project/zones/us-west1-b/disks/my-instance-boot",
+          "type": "compute.disks"
+        }
+      },
+      {
+        "permission": "compute.disks.setLabels",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/my-project/zones/us-west1-b/disks/my-instance-boot",
+          "type": "compute.disks"
+        }
+      },
+      {
+        "permission": "compute.disks.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/my-project/zones/us-west1-b/disks/my-instance-data",
+          "type": "compute.disks"
+        }
+      },
+      {
+        "permission": "compute.disks.setLabels",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/my-project/zones/us-west1-b/disks/my-instance-data",
+          "type": "compute.disks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.use",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/my-project/regions/us-west1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.useExternalIp",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/my-project/regions/us-west1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.instances.setMetadata",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/my-project/zones/us-west1-b/instances/my-instance",
+          "type": "compute.instances"
+        }
+      },
+      {
+        "permission": "compute.instances.setTags",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/my-project/zones/us-west1-b/instances/my-instance",
+          "type": "compute.instances"
+        }
+      },
+      {
+        "permission": "compute.instances.setLabels",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/my-project/zones/us-west1-b/instances/my-instance",
+          "type": "compute.instances"
+        }
+      },
+      {
+        "permission": "compute.instances.setServiceAccount",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/my-project/zones/us-west1-b/instances/my-instance",
+          "type": "compute.instances"
+        }
+      }
+    ],
+    "resourceName": "projects/my-project/zones/us-west1-b/instances/my-instance",
+    "request": {
+      "requestId": "bfe11378-6130-42d4-babb-82f697690ac8",
+      "machineType": "zones/us-west1-b/machineTypes/n1-standard-4",
+      "@type": "type.googleapis.com/compute.instances.insert",
+      "serviceAccounts": [
+        {
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/userinfo.email"
+          ],
+          "email": "compute-full@my-project.iam.gserviceaccount.com"
+        }
+      ],
+      "tags": {
+        "tags": [
+          "deeplearning-vm",
+          "notebook-instance"
+        ]
+      },
+      "labels": [
+        {
+          "key": "goog-caip-notebook",
+          "value": ""
+        }
+      ],
+      "scheduling": {
+        "onHostMaintenance": "MIGRATE"
+      },
+      "name": "my-instance",
+      "networkInterfaces": [
+        {
+          "nicType": "UNSPECIFIED_NIC_TYPE",
+          "network": "projects/my-project/global/networks/default",
+          "subnetwork": "projects/my-project/regions/us-west1/subnetworks/default",
+          "accessConfigs": [
+            {
+              "type": "ONE_TO_ONE_NAT",
+              "name": "external-nat"
+            }
+          ]
+        }
+      ],
+      "disks": [
+        {
+          "type": "PERSISTENT",
+          "deviceName": "boot",
+          "autoDelete": true,
+          "boot": true,
+          "initializeParams": {
+            "diskType": "projects/my-project/zones/us-west1-b/diskTypes/pd-standard",
+            "sourceImage": "projects/deeplearning-platform-release/global/images/family/common-cpu-notebooks-debian-10",
+            "diskName": "my-instance-boot",
+            "labels": [
+              {
+                "key": "goog-caip-notebook-volume",
+                "value": ""
+              }
+            ],
+            "diskSizeGb": "100"
+          }
+        },
+        {
+          "type": "PERSISTENT",
+          "autoDelete": true,
+          "initializeParams": {
+            "diskType": "projects/my-project/zones/us-west1-b/diskTypes/pd-standard",
+            "diskSizeGb": "100",
+            "labels": [
+              {
+                "key": "goog-caip-notebook-volume",
+                "value": ""
+              }
+            ],
+            "diskName": "my-instance-data"
+          },
+          "deviceName": "data"
+        }
+      ]
+    },
+    "response": {
+      "insertTime": "2021-04-15T10:43:09.881-07:00",
+      "operationType": "insert",
+      "targetId": "4224659083998119362",
+      "targetLink": "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-west1-b/instances/my-instance",
+      "name": "operation-1618508588353-5c0066579885a-833360e6-629e748b",
+      "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-west1-b/operations/4053444786883249602",
+      "startTime": "2021-04-15T10:43:09.883-07:00",
+      "clientOperationId": "bfe11378-6130-42d4-babb-82f697690ac8",
+      "id": "4053444786883249602",
+      "status": "RUNNING",
+      "@type": "type.googleapis.com/operation",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-west1-b/operations/operation-1618508588353-5c0066579885a-833360e6-629e748b",
+      "progress": "0",
+      "zone": "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-west1-b",
+      "user": "service-000000000000@gcp-sa-notebooks.iam.gserviceaccount.com"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-west1-b"
+      ]
+    }
+  },
+  "insertId": "r78f6xe3o5bi",
+  "resource": {
+    "type": "gce_instance",
+    "labels": {
+      "zone": "us-west1-b",
+      "instance_id": "4224659083998119362",
+      "project_id": "my-project"
+    }
+  },
+  "timestamp": "2021-04-15T17:43:08.405047Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1618508588353-5c0066579885a-833360e6-629e748b",
+    "producer": "compute.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-04-15T17:43:10.665978926Z"
+}

--- a/tests/data/compute-subnetworks-enable-flow-logs.json
+++ b/tests/data/compute-subnetworks-enable-flow-logs.json
@@ -1,0 +1,78 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0.0.0.0",
+      "callerSuppliedUserAgent": "useragent",
+      "requestAttributes": {
+        "time": "1970-01-01T00:00:00.000Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.subnetworks.patch",
+    "authorizationInfo": [
+      {
+        "permission": "compute.subnetworks.update",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/example-project/regions/us-east1/subnetworks/example",
+          "type": "compute.subnetworks"
+        }
+      }
+    ],
+    "resourceName": "projects/example-project/regions/us-east1/subnetworks/example",
+    "request": {
+      "fingerprint": "&%\t�^�xt",
+      "@type": "type.googleapis.com/compute.subnetworks.patch",
+      "enableFlowLogs": true
+    },
+    "response": {
+      "endTime": "1970-01-01T00:00:00.000Z",
+      "@type": "type.googleapis.com/operation",
+      "startTime": "1970-01-01T00:00:00.000Z",
+      "progress": "100",
+      "insertTime": "1970-01-01T00:00:00.000Z",
+      "user": "user@example.com",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/example-project/regions/us-east1/operations/000cc00c-0000-00f0-0e00-00c0c000ddf0",
+      "targetLink": "https://www.googleapis.com/compute/v1/projects/example-project/regions/us-east1/subnetworks/example",
+      "operationType": "compute.subnetworks.patch",
+      "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/example-project/regions/us-east1/operations/0000000000000000000",
+      "region": "https://www.googleapis.com/compute/v1/projects/example-project/regions/us-east1",
+      "status": "DONE",
+      "name": "000cc00c-0000-00f0-0e00-00c0c000ddf0",
+      "targetId": "00000000000000000",
+      "id": "0000000000000000000"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-east1"
+      ]
+    }
+  },
+  "insertId": "0000000000",
+  "resource": {
+    "type": "gce_subnetwork",
+    "labels": {
+      "subnetwork_id": "00000000000000000",
+      "location": "us-east1",
+      "subnetwork_name": "example",
+      "project_id": "example-project"
+    }
+  },
+  "timestamp": "1970-01-01T00:00:00.000Z",
+  "severity": "NOTICE",
+  "logName": "projects/example-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "000cc00c-0000-00f0-0e00-00c0c000ddf0",
+    "producer": "type.googleapis.com",
+    "first": true,
+    "last": true
+  },
+  "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+}

--- a/tests/data/compute-subnetworks-set-private-ip-google-access.json
+++ b/tests/data/compute-subnetworks-set-private-ip-google-access.json
@@ -1,0 +1,75 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0.0.0.0",
+      "callerSuppliedUserAgent": "useragent",
+      "requestAttributes": {
+        "time": "1970-01-01T00:00:00.000Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.subnetworks.setPrivateIpGoogleAccess",
+    "authorizationInfo": [
+      {
+        "permission": "compute.subnetworks.setPrivateIpGoogleAccess",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/example-project/regions/us-east1/subnetworks/example",
+          "type": "compute.subnetworks"
+        }
+      }
+    ],
+    "resourceName": "projects/example-project/regions/us-east1/subnetworks/example",
+    "request": {
+      "@type": "type.googleapis.com/compute.subnetworks.setPrivateIpGoogleAccess",
+      "privateIpGoogleAccess": false
+    },
+    "response": {
+      "operationType": "setPrivateIpGoogleAccess",
+      "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/example-project/regions/us-east1/operations/0000000000000000000",
+      "region": "https://www.googleapis.com/compute/v1/projects/example-project/regions/us-east1",
+      "status": "RUNNING",
+      "name": "000cc00c-0000-00f0-0e00-00c0c000ddf0",
+      "targetId": "0000000000000000000",
+      "id": "0000000000000000000",
+      "@type": "type.googleapis.com/operation",
+      "startTime": "1970-01-01T00:00:00.000Z",
+      "progress": "0",
+      "insertTime": "1970-01-01T00:00:00.000Z",
+      "user": "user@example.com",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/example-project/regions/us-east1/operations/000cc00c-0000-00f0-0e00-00c0c000ddf0",
+      "targetLink": "https://www.googleapis.com/compute/v1/projects/example-project/regions/us-east1/subnetworks/example"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-east1"
+      ]
+    }
+  },
+  "insertId": "0000000000",
+  "resource": {
+    "type": "gce_subnetwork",
+    "labels": {
+      "project_id": "example-project",
+      "subnetwork_id": "0000000000000000000",
+      "location": "us-east1",
+      "subnetwork_name": "example"
+    }
+  },
+  "timestamp": "1970-01-01T00:00:00.000Z",
+  "severity": "NOTICE",
+  "logName": "projects/example-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "000cc00c-0000-00f0-0e00-00c0c000ddf0",
+    "producer": "type.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+}

--- a/tests/data/compute_instance_creation_logs_1.json
+++ b/tests/data/compute_instance_creation_logs_1.json
@@ -1,0 +1,193 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "test.user@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "76.98.160.101",
+      "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:88.0) Gecko/20100101 Firefox/88.0,gzip(gfe),gzip(gfe)",
+      "requestAttributes": {
+        "time": "2021-04-23T19:35:57.750392Z",
+        "reason": "8uSywAYQGg5Db2xpc2V1bSBGbG93cw",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "beta.compute.instances.insert",
+    "authorizationInfo": [
+      {
+        "permission": "compute.instances.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/instances/console-devicenames",
+          "type": "compute.instances"
+        }
+      },
+      {
+        "permission": "compute.disks.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/disks/console-devicenames",
+          "type": "compute.disks"
+        }
+      },
+      {
+        "permission": "compute.disks.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/disks/disk2name",
+          "type": "compute.disks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.use",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/regions/us-central1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.useExternalIp",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/regions/us-central1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.instances.setServiceAccount",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/instances/console-devicenames",
+          "type": "compute.instances"
+        }
+      }
+    ],
+    "resourceName": "projects/test-project/zones/us-central1-a/instances/console-devicenames",
+    "request": {
+      "scheduling": {
+        "onHostMaintenance": "MIGRATE",
+        "automaticRestart": true,
+        "preemptible": false
+      },
+      "serviceAccounts": [
+        {
+          "email": "714682308094-compute@developer.gserviceaccount.com",
+          "scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_only",
+            "https://www.googleapis.com/auth/logging.write",
+            "https://www.googleapis.com/auth/monitoring.write",
+            "https://www.googleapis.com/auth/servicecontrol",
+            "https://www.googleapis.com/auth/service.management.readonly",
+            "https://www.googleapis.com/auth/trace.append"
+          ]
+        }
+      ],
+      "reservationAffinity": {
+        "consumeReservationType": "ANY_ALLOCATION"
+      },
+      "shieldedInstanceConfig": {
+        "enableVtpm": true,
+        "enableSecureBoot": false,
+        "enableIntegrityMonitoring": true
+      },
+      "machineType": "projects/test-project/zones/us-central1-a/machineTypes/e2-medium",
+      "displayDevice": {
+        "enableDisplay": false
+      },
+      "confidentialInstanceConfig": {
+        "enableConfidentialCompute": false
+      },
+      "name": "console-devicenames",
+      "deletionProtection": false,
+      "disks": [
+        {
+          "autoDelete": true,
+          "type": "PERSISTENT",
+          "deviceName": "devicename",
+          "boot": true,
+          "mode": "READ_WRITE",
+          "initializeParams": {
+            "diskSizeGb": "10",
+            "sourceImage": "projects/debian-cloud/global/images/debian-10-buster-v20210420",
+            "diskType": "projects/test-project/zones/us-central1-a/diskTypes/pd-balanced"
+          }
+        },
+        {
+          "autoDelete": false,
+          "mode": "READ_WRITE",
+          "initializeParams": {
+            "diskType": "projects/test-project/zones/us-central1-a/diskTypes/pd-balanced",
+            "diskSizeGb": "500",
+            "description": "",
+            "diskName": "disk2name"
+          },
+          "deviceName": "disk2devicename",
+          "type": "PERSISTENT"
+        }
+      ],
+      "@type": "type.googleapis.com/compute.instances.insert",
+      "networkInterfaces": [
+        {
+          "subnetwork": "projects/test-project/regions/us-central1/subnetworks/default",
+          "accessConfigs": [
+            {
+              "networkTier": "PREMIUM",
+              "name": "External NAT"
+            }
+          ]
+        }
+      ],
+      "description": "",
+      "canIpForward": false
+    },
+    "response": {
+      "@type": "type.googleapis.com/operation",
+      "name": "operation-1619206556904-5c0a8e7a46b69-07d8da26-0d3c1532",
+      "user": "test.user@cleardata.com",
+      "progress": "0",
+      "status": "RUNNING",
+      "selfLink": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a/operations/operation-1619206556904-5c0a8e7a46b69-07d8da26-0d3c1532",
+      "operationType": "insert",
+      "selfLinkWithId": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a/operations/2395682771775168370",
+      "id": "2395682771775168370",
+      "targetId": "1515444269730406258",
+      "targetLink": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a/instances/console-devicenames",
+      "insertTime": "2021-04-23T12:35:57.567-07:00",
+      "zone": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a",
+      "startTime": "2021-04-23T12:35:57.570-07:00"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-central1-a"
+      ]
+    }
+  },
+  "insertId": "77sfxfe1ryso",
+  "resource": {
+    "type": "gce_instance",
+    "labels": {
+      "zone": "us-central1-a",
+      "instance_id": "1515444269730406258",
+      "project_id": "test-project"
+    }
+  },
+  "timestamp": "2021-04-23T19:35:56.947852Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1619206556904-5c0a8e7a46b69-07d8da26-0d3c1532",
+    "producer": "compute.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-04-23T19:35:58.649788422Z"
+}

--- a/tests/data/compute_instance_creation_logs_2.json
+++ b/tests/data/compute_instance_creation_logs_2.json
@@ -1,0 +1,36 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "test.user@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "76.98.160.101",
+      "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:88.0) Gecko/20100101 Firefox/88.0,gzip(gfe),gzip(gfe)"
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "beta.compute.instances.insert",
+    "resourceName": "projects/test-project/zones/us-central1-a/instances/console-devicenames",
+    "request": {
+      "@type": "type.googleapis.com/compute.instances.insert"
+    }
+  },
+  "insertId": "k9bodhd531s",
+  "resource": {
+    "type": "gce_instance",
+    "labels": {
+      "zone": "us-central1-a",
+      "project_id": "test-project",
+      "instance_id": "1515444269730406258"
+    }
+  },
+  "timestamp": "2021-04-23T19:36:05.525118Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1619206556904-5c0a8e7a46b69-07d8da26-0d3c1532",
+    "producer": "compute.googleapis.com",
+    "last": true
+  },
+  "receiveTimestamp": "2021-04-23T19:36:06.110416993Z"
+}

--- a/tests/data/compute_instance_creation_logs_3.json
+++ b/tests/data/compute_instance_creation_logs_3.json
@@ -1,0 +1,172 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "test.user@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "76.98.160.101",
+      "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:88.0) Gecko/20100101 Firefox/88.0,gzip(gfe),gzip(gfe)",
+      "requestAttributes": {
+        "time": "2021-04-23T19:36:17.686966Z",
+        "reason": "8uSywAYQGg5Db2xpc2V1bSBGbG93cw",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "beta.compute.instances.insert",
+    "authorizationInfo": [
+      {
+        "permission": "compute.instances.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/instances/console-nochange",
+          "type": "compute.instances"
+        }
+      },
+      {
+        "permission": "compute.disks.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/disks/console-nochange",
+          "type": "compute.disks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.use",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/regions/us-central1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.useExternalIp",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/regions/us-central1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.instances.setServiceAccount",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/instances/console-nochange",
+          "type": "compute.instances"
+        }
+      }
+    ],
+    "resourceName": "projects/test-project/zones/us-central1-a/instances/console-nochange",
+    "request": {
+      "description": "",
+      "deletionProtection": false,
+      "name": "console-nochange",
+      "scheduling": {
+        "automaticRestart": true,
+        "preemptible": false,
+        "onHostMaintenance": "MIGRATE"
+      },
+      "disks": [
+        {
+          "mode": "READ_WRITE",
+          "boot": true,
+          "initializeParams": {
+            "diskSizeGb": "10",
+            "diskType": "projects/test-project/zones/us-central1-a/diskTypes/pd-balanced",
+            "sourceImage": "projects/debian-cloud/global/images/debian-10-buster-v20210420"
+          },
+          "autoDelete": true,
+          "deviceName": "console-nochange",
+          "type": "PERSISTENT"
+        }
+      ],
+      "serviceAccounts": [
+        {
+          "scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_only",
+            "https://www.googleapis.com/auth/logging.write",
+            "https://www.googleapis.com/auth/monitoring.write",
+            "https://www.googleapis.com/auth/servicecontrol",
+            "https://www.googleapis.com/auth/service.management.readonly",
+            "https://www.googleapis.com/auth/trace.append"
+          ],
+          "email": "714682308094-compute@developer.gserviceaccount.com"
+        }
+      ],
+      "reservationAffinity": {
+        "consumeReservationType": "ANY_ALLOCATION"
+      },
+      "shieldedInstanceConfig": {
+        "enableSecureBoot": false,
+        "enableVtpm": true,
+        "enableIntegrityMonitoring": true
+      },
+      "machineType": "projects/test-project/zones/us-central1-a/machineTypes/e2-medium",
+      "@type": "type.googleapis.com/compute.instances.insert",
+      "canIpForward": false,
+      "confidentialInstanceConfig": {
+        "enableConfidentialCompute": false
+      },
+      "displayDevice": {
+        "enableDisplay": false
+      },
+      "networkInterfaces": [
+        {
+          "subnetwork": "projects/test-project/regions/us-central1/subnetworks/default",
+          "accessConfigs": [
+            {
+              "networkTier": "PREMIUM",
+              "name": "External NAT"
+            }
+          ]
+        }
+      ]
+    },
+    "response": {
+      "operationType": "insert",
+      "progress": "0",
+      "status": "RUNNING",
+      "id": "7760612956209848158",
+      "targetLink": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a/instances/console-nochange",
+      "name": "operation-1619206576834-5c0a8e8d4874b-37ab70b0-80662f0b",
+      "startTime": "2021-04-23T12:36:17.518-07:00",
+      "targetId": "7230167568687734622",
+      "zone": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a",
+      "selfLink": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a/operations/operation-1619206576834-5c0a8e8d4874b-37ab70b0-80662f0b",
+      "selfLinkWithId": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a/operations/7760612956209848158",
+      "user": "test.user@cleardata.com",
+      "@type": "type.googleapis.com/operation",
+      "insertTime": "2021-04-23T12:36:17.515-07:00"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-central1-a"
+      ]
+    }
+  },
+  "insertId": "mhibhfe1ycbg",
+  "resource": {
+    "type": "gce_instance",
+    "labels": {
+      "project_id": "test-project",
+      "zone": "us-central1-a",
+      "instance_id": "7230167568687734622"
+    }
+  },
+  "timestamp": "2021-04-23T19:36:16.875922Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1619206576834-5c0a8e8d4874b-37ab70b0-80662f0b",
+    "producer": "compute.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-04-23T19:36:18.213428055Z"
+}

--- a/tests/data/compute_instance_creation_logs_4.json
+++ b/tests/data/compute_instance_creation_logs_4.json
@@ -1,0 +1,153 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "test.user@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "76.98.160.101",
+      "callerSuppliedUserAgent": "google-cloud-sdk gcloud/327.0.0 command/gcloud.compute.instances.create invocation-id/6e49e932e1a34fbd9db966d667014b9e environment/None environment-version/None interactive/True from-script/False python/3.7.8 term/xterm-256color (Macintosh; Intel Mac OS X 20.3.0),gzip(gfe)",
+      "requestAttributes": {
+        "time": "2021-04-23T19:40:10.894836Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.instances.insert",
+    "authorizationInfo": [
+      {
+        "permission": "compute.instances.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/instances/gcloud-devicename-mismatch",
+          "type": "compute.instances"
+        }
+      },
+      {
+        "permission": "compute.disks.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/disks/gcloud-devicename-mismatch",
+          "type": "compute.disks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.use",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/regions/us-central1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.useExternalIp",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/regions/us-central1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.instances.setServiceAccount",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/instances/gcloud-devicename-mismatch",
+          "type": "compute.instances"
+        }
+      }
+    ],
+    "resourceName": "projects/test-project/zones/us-central1-a/instances/gcloud-devicename-mismatch",
+    "request": {
+      "deletionProtection": false,
+      "serviceAccounts": [
+        {
+          "scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_only",
+            "https://www.googleapis.com/auth/logging.write",
+            "https://www.googleapis.com/auth/monitoring.write",
+            "https://www.googleapis.com/auth/pubsub",
+            "https://www.googleapis.com/auth/service.management.readonly",
+            "https://www.googleapis.com/auth/servicecontrol",
+            "https://www.googleapis.com/auth/trace.append"
+          ],
+          "email": "default"
+        }
+      ],
+      "name": "gcloud-devicename-mismatch",
+      "canIpForward": false,
+      "scheduling": {
+        "automaticRestart": true
+      },
+      "machineType": "https://compute.googleapis.com/compute/v1/projects/test-project/zones/us-central1-a/machineTypes/n1-standard-1",
+      "@type": "type.googleapis.com/compute.instances.insert",
+      "networkInterfaces": [
+        {
+          "accessConfigs": [
+            {
+              "name": "external-nat",
+              "type": "ONE_TO_ONE_NAT"
+            }
+          ],
+          "network": "https://compute.googleapis.com/compute/v1/projects/test-project/global/networks/default"
+        }
+      ],
+      "disks": [
+        {
+          "mode": "READ_WRITE",
+          "boot": true,
+          "deviceName": "booter",
+          "initializeParams": {
+            "sourceImage": "https://compute.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10"
+          },
+          "autoDelete": true,
+          "type": "PERSISTENT"
+        }
+      ]
+    },
+    "response": {
+      "status": "RUNNING",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-central1-a/operations/operation-1619206809737-5c0a8f6b65a76-ee4c1773-b89215cb",
+      "targetId": "6816838088127323253",
+      "startTime": "2021-04-23T12:40:10.699-07:00",
+      "id": "4483070932426857589",
+      "@type": "type.googleapis.com/operation",
+      "user": "test.user@cleardata.com",
+      "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-central1-a/operations/4483070932426857589",
+      "zone": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-central1-a",
+      "name": "operation-1619206809737-5c0a8f6b65a76-ee4c1773-b89215cb",
+      "operationType": "insert",
+      "insertTime": "2021-04-23T12:40:10.696-07:00",
+      "targetLink": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-central1-a/instances/gcloud-devicename-mismatch",
+      "progress": "0"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-central1-a"
+      ]
+    }
+  },
+  "insertId": "-o4ntu5e1o6ji",
+  "resource": {
+    "type": "gce_instance",
+    "labels": {
+      "project_id": "test-project",
+      "zone": "us-central1-a",
+      "instance_id": "6816838088127323253"
+    }
+  },
+  "timestamp": "2021-04-23T19:40:09.792987Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1619206809737-5c0a8f6b65a76-ee4c1773-b89215cb",
+    "producer": "compute.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-04-23T19:40:11.435692357Z"
+}

--- a/tests/data/compute_instance_creation_logs_5.json
+++ b/tests/data/compute_instance_creation_logs_5.json
@@ -1,0 +1,118 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "service-974894326962@gcp-sa-notebooks.iam.gserviceaccount.com"
+    },
+    "requestMetadata": {},
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.instances.insert",
+    "resourceName": "projects/test-project/zones/us-west1-b/instances/demo-testing-good",
+    "request": {
+      "requestId": "bfe11378-6130-42d4-babb-82f697690ac8",
+      "machineType": "zones/us-west1-b/machineTypes/n1-standard-4",
+      "@type": "type.googleapis.com/compute.instances.insert",
+      "serviceAccounts": [
+        {
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/userinfo.email"
+          ],
+          "email": "compute-full@test-project.iam.gserviceaccount.com"
+        }
+      ],
+      "tags": {
+        "tags": [
+          "deeplearning-vm",
+          "notebook-instance"
+        ]
+      },
+      "labels": [
+        {
+          "key": "goog-caip-notebook",
+          "value": ""
+        }
+      ],
+      "scheduling": {
+        "onHostMaintenance": "MIGRATE"
+      },
+      "name": "demo-testing-good",
+      "disks": [
+        {
+          "type": "PERSISTENT",
+          "deviceName": "boot",
+          "autoDelete": true,
+          "boot": true,
+          "initializeParams": {
+            "diskType": "projects/test-project/zones/us-west1-b/diskTypes/pd-standard",
+            "sourceImage": "projects/deeplearning-platform-release/global/images/family/common-cpu-notebooks-debian-10",
+            "diskName": "demo-testing-good-boot",
+            "labels": [
+              {
+                "key": "goog-caip-notebook-volume",
+                "value": ""
+              }
+            ],
+            "diskSizeGb": "100"
+          }
+        },
+        {
+          "type": "PERSISTENT",
+          "autoDelete": true,
+          "initializeParams": {
+            "diskType": "projects/test-project/zones/us-west1-b/diskTypes/pd-standard",
+            "diskSizeGb": "100",
+            "labels": [
+              {
+                "key": "goog-caip-notebook-volume",
+                "value": ""
+              }
+            ],
+            "diskName": "demo-testing-good-data"
+          },
+          "deviceName": "data"
+        }
+      ]
+    },
+    "response": {
+      "insertTime": "2021-04-15T10:43:09.881-07:00",
+      "operationType": "insert",
+      "targetId": "4224659083998119362",
+      "targetLink": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b/instances/demo-testing-good",
+      "name": "operation-1618508588353-5c0066579885a-833360e6-629e748b",
+      "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b/operations/4053444786883249602",
+      "startTime": "2021-04-15T10:43:09.883-07:00",
+      "clientOperationId": "bfe11378-6130-42d4-babb-82f697690ac8",
+      "id": "4053444786883249602",
+      "status": "RUNNING",
+      "@type": "type.googleapis.com/operation",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b/operations/operation-1618508588353-5c0066579885a-833360e6-629e748b",
+      "progress": "0",
+      "zone": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b",
+      "user": "service-974894326962@gcp-sa-notebooks.iam.gserviceaccount.com"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-west1-b"
+      ]
+    }
+  },
+  "insertId": "r78f6xe3o5bi",
+  "resource": {
+    "type": "gce_instance",
+    "labels": {
+      "zone": "us-west1-b",
+      "instance_id": "4224659083998119362",
+      "project_id": "test-project"
+    }
+  },
+  "timestamp": "2021-04-15T17:43:08.405047Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1618508588353-5c0066579885a-833360e6-629e748b",
+    "producer": "compute.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-04-15T17:43:10.665978926Z"
+}

--- a/tests/data/compute_networks_insert_1.json
+++ b/tests/data/compute_networks_insert_1.json
@@ -1,0 +1,79 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "user@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "203.0.113.34",
+      "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:89.0) Gecko/20100101 Firefox/89.0,gzip(gfe),gzip(gfe)",
+      "requestAttributes": {
+        "time": "2021-06-29T21:04:56.478289Z",
+        "reason": "8uSywAYQGg5Db2xpc2V1bSBGbG93cw",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "beta.compute.networks.insert",
+    "authorizationInfo": [
+      {
+        "permission": "compute.networks.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project-1/global/networks/xyz",
+          "type": "compute.networks"
+        }
+      }
+    ],
+    "resourceName": "projects/test-project-1/global/networks/xyz",
+    "request": {
+      "routingConfig": {
+        "routingMode": "REGIONAL"
+      },
+      "description": "",
+      "name": "xyz",
+      "autoCreateSubnetworks": false,
+      "mtu": "1460",
+      "@type": "type.googleapis.com/compute.networks.insert"
+    },
+    "response": {
+      "status": "RUNNING",
+      "targetId": "7947007926906270743",
+      "targetLink": "https://www.googleapis.com/compute/beta/projects/test-project-1/global/networks/xyz",
+      "user": "user@cleardata.com",
+      "@type": "type.googleapis.com/operation",
+      "selfLink": "https://www.googleapis.com/compute/beta/projects/test-project-1/global/operations/operation-1625000696006-5c5edf53ec8e0-6aeebfa5-320c28ee",
+      "progress": "0",
+      "operationType": "insert",
+      "insertTime": "2021-06-29T14:04:56.263-07:00",
+      "name": "operation-1625000696006-5c5edf53ec8e0-6aeebfa5-320c28ee",
+      "startTime": "2021-06-29T14:04:56.268-07:00",
+      "id": "6582662276287181847",
+      "selfLinkWithId": "https://www.googleapis.com/compute/beta/projects/test-project-1/global/operations/6582662276287181847"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "global"
+      ]
+    }
+  },
+  "insertId": "-oenoe7djxto",
+  "resource": {
+    "type": "gce_network",
+    "labels": {
+      "network_id": "7947007926906270743",
+      "project_id": "test-project-1"
+    }
+  },
+  "timestamp": "2021-06-29T21:04:56.052843Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project-1/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1625000696006-5c5edf53ec8e0-6aeebfa5-320c28ee",
+    "producer": "compute.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-06-29T21:04:57.360571693Z"
+}

--- a/tests/data/compute_networks_insert_2.json
+++ b/tests/data/compute_networks_insert_2.json
@@ -1,0 +1,77 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "user@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "203.0.113.34",
+      "callerSuppliedUserAgent": "google-cloud-sdk gcloud/341.0.0 command/gcloud.compute.networks.create invocation-id/84b4108326804a548629bda82d9cc0ea environment/None environment-version/None interactive/true from-script/false python/3.8.10 term/xterm-256color (Macintosh; Intel Mac OS X 20.5.0),gzip(gfe)",
+      "requestAttributes": {
+        "time": "2021-06-29T21:05:12.588339Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.networks.insert",
+    "authorizationInfo": [
+      {
+        "permission": "compute.networks.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project-1/global/networks/xyzcli",
+          "type": "compute.networks"
+        }
+      }
+    ],
+    "resourceName": "projects/test-project-1/global/networks/xyzcli",
+    "request": {
+      "routingConfig": {
+        "routingMode": "REGIONAL"
+      },
+      "@type": "type.googleapis.com/compute.networks.insert",
+      "mtu": "1460",
+      "autoCreateSubnetworks": false,
+      "name": "xyzcli"
+    },
+    "response": {
+      "operationType": "insert",
+      "startTime": "2021-06-29T14:05:12.427-07:00",
+      "targetLink": "https://www.googleapis.com/compute/v1/projects/test-project-1/global/networks/xyzcli",
+      "status": "RUNNING",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/test-project-1/global/operations/operation-1625000712103-5c5edf634652f-1790f250-3f762fe6",
+      "insertTime": "2021-06-29T14:05:12.413-07:00",
+      "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/test-project-1/global/operations/8931384447982777831",
+      "user": "user@cleardata.com",
+      "name": "operation-1625000712103-5c5edf634652f-1790f250-3f762fe6",
+      "progress": "0",
+      "targetId": "283459718653294055",
+      "id": "8931384447982777831",
+      "@type": "type.googleapis.com/operation"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "global"
+      ]
+    }
+  },
+  "insertId": "ktglm2digpi",
+  "resource": {
+    "type": "gce_network",
+    "labels": {
+      "network_id": "283459718653294055",
+      "project_id": "test-project-1"
+    }
+  },
+  "timestamp": "2021-06-29T21:05:12.164976Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project-1/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1625000712103-5c5edf634652f-1790f250-3f762fe6",
+    "producer": "compute.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-06-29T21:05:13.497646003Z"
+}

--- a/tests/data/compute_networks_insert_3.json
+++ b/tests/data/compute_networks_insert_3.json
@@ -1,0 +1,72 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "user@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "203.0.113.34",
+      "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:89.0) Gecko/20100101 Firefox/89.0,gzip(gfe),gzip(gfe)",
+      "requestAttributes": {
+        "time": "2021-06-29T21:13:33.519328Z",
+        "reason": "8uSywAYQGg5Db2xpc2V1bSBGbG93cw",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "beta.compute.networks.switchToCustomMode",
+    "authorizationInfo": [
+      {
+        "permission": "compute.networks.switchToCustomMode",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project-1/global/networks/datalab-network",
+          "type": "compute.networks"
+        }
+      }
+    ],
+    "resourceName": "projects/test-project-1/global/networks/datalab-network",
+    "request": {
+      "@type": "type.googleapis.com/compute.networks.switchToCustomMode"
+    },
+    "response": {
+      "operationType": "switchToCustomMode",
+      "targetLink": "https://www.googleapis.com/compute/beta/projects/test-project-1/global/networks/datalab-network",
+      "name": "operation-1625001213182-5c5ee14124162-336a7285-a2fd591b",
+      "targetId": "7494160576814322555",
+      "id": "1951361417096868370",
+      "selfLink": "https://www.googleapis.com/compute/beta/projects/test-project-1/global/operations/operation-1625001213182-5c5ee14124162-336a7285-a2fd591b",
+      "user": "user@cleardata.com",
+      "progress": "0",
+      "insertTime": "2021-06-29T14:13:33.361-07:00",
+      "@type": "type.googleapis.com/operation",
+      "startTime": "2021-06-29T14:13:33.364-07:00",
+      "selfLinkWithId": "https://www.googleapis.com/compute/beta/projects/test-project-1/global/operations/1951361417096868370",
+      "status": "RUNNING"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "global"
+      ]
+    }
+  },
+  "insertId": "qngc7ndh3r8",
+  "resource": {
+    "type": "gce_network",
+    "labels": {
+      "network_id": "7494160576814322555",
+      "project_id": "test-project-1"
+    }
+  },
+  "timestamp": "2021-06-29T21:13:33.218802Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project-1/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1625001213182-5c5ee14124162-336a7285-a2fd591b",
+    "producer": "compute.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-06-29T21:13:33.648921070Z"
+}

--- a/tests/data/dataflow-job-step.json
+++ b/tests/data/dataflow-job-step.json
@@ -1,0 +1,52 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "principalEmail@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "69.420.13.37",
+      "requestAttributes": {
+        "time": "2021-03-18T20:19:14.968012858Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "dataflow.googleapis.com",
+    "methodName": "dataflow.jobs.create",
+    "authorizationInfo": [
+      {
+        "resource": "projects/my-project",
+        "permission": "dataflow.jobs.create",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "request": {
+      "job_id": "job-id",
+      "job_name": "job-name",
+      "serviceAccount": "0000000000-compute@developer.gserviceaccount.com"
+    },
+    "response": {},
+    "resourceLocation": {
+      "currentLocations": [
+        "us-central1"
+      ]
+    }
+  },
+  "insertId": "1lzxdzfblc",
+  "resource": {
+    "type": "dataflow_step",
+    "labels": {
+      "step_id": "",
+      "region": "us-central1",
+      "project_id": "my-project",
+      "job_id": "",
+      "job_name": ""
+    }
+  },
+  "timestamp": "2021-03-18T20:19:14.963553594Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "receiveTimestamp": "2021-03-18T20:19:15.390745371Z"
+}

--- a/tests/data/datafusion-create-instance.json
+++ b/tests/data/datafusion-create-instance.json
@@ -1,0 +1,58 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "joe.ceresini@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "::1",
+      "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:87.0) Gecko/20100101 Firefox/87.0,gzip(gfe),gzip(gfe)",
+      "requestAttributes": {
+        "time": "2021-04-21T13:42:07.054592956Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "datafusion.googleapis.com",
+    "methodName": "google.cloud.datafusion.v1.DataFusion.CreateInstance",
+    "authorizationInfo": [
+      {
+        "resource": "projects/test-project/locations/us-west1/instances/test-instance",
+        "permission": "datafusion.instances.create",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "projects/test-project/locations/us-west1/instances/test-instance",
+    "request": {
+      "@type": "type.googleapis.com/google.cloud.datafusion.v1.CreateInstanceRequest"
+    },
+    "response": {
+      "@type": "type.googleapis.com/google.longrunning.Operation"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-west1"
+      ]
+    }
+  },
+  "insertId": "1g69r0ld18a8",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "project_id": "test-project",
+      "method": "google.cloud.datafusion.v1.DataFusion.CreateInstance",
+      "service": "datafusion.googleapis.com"
+    }
+  },
+  "timestamp": "2021-04-21T13:42:07.141616Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "projects/test-project/locations/us-west1/operations/operation-1619012527071-5c07bba902145-73cd6799-4b75b165",
+    "producer": "datafusion.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-04-21T13:42:08.102032180Z"
+}

--- a/tests/data/datafusion-update-instance.json
+++ b/tests/data/datafusion-update-instance.json
@@ -1,0 +1,62 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "joe.ceresini@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "::1",
+      "callerSuppliedUserAgent": "(gzip),gzip(gfe),gzip(gfe)",
+      "requestAttributes": {
+        "time": "2021-04-21T14:29:45.687025537Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "datafusion.googleapis.com",
+    "methodName": "google.cloud.datafusion.v1beta1.DataFusion.UpdateInstance",
+    "authorizationInfo": [
+      {
+        "resource": "projects/test-project/locations/us-west1/instances/test-instance",
+        "permission": "datafusion.instances.update",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "projects/test-project/locations/us-west1/instances/test-instance",
+    "request": {
+      "instance": {
+        "enable_stackdriver_logging": true,
+        "name": "projects/test-project/locations/us-west1/instances/test-instance"
+      },
+      "@type": "type.googleapis.com/google.cloud.datafusion.v1beta1.UpdateInstanceRequest"
+    },
+    "response": {
+      "@type": "type.googleapis.com/google.longrunning.Operation"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-west1"
+      ]
+    }
+  },
+  "insertId": "rr7kkmcwmc",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "method": "google.cloud.datafusion.v1beta1.DataFusion.UpdateInstance",
+      "service": "datafusion.googleapis.com",
+      "project_id": "test-project"
+    }
+  },
+  "timestamp": "2021-04-21T14:29:45.751408435Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "projects/test-project/locations/us-west1/operations/operation-1619015385689-5c07c64f32eba-f4b8056e-3f7c0908",
+    "producer": "datafusion.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-04-21T14:29:46.085095772Z"
+}

--- a/tests/data/dataproc_createcluster.json
+++ b/tests/data/dataproc_createcluster.json
@@ -1,0 +1,90 @@
+{
+   "protoPayload": {
+     "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+     "status": {},
+     "authenticationInfo": {
+       "principalEmail": "user@domain.com"
+     },
+     "requestMetadata": {
+       "callerIp": "123.123.123.123",
+       "callerSuppliedUserAgent": "user_agent",
+       "requestAttributes": {
+         "time": "1970-01-01T00:00:00.000Z",
+         "auth": {}
+       },
+       "destinationAttributes": {}
+     },
+     "serviceName": "dataproc.googleapis.com",
+     "methodName": "google.cloud.dataproc.v1beta2.ClusterController.CreateCluster",
+     "authorizationInfo": [
+       {
+         "permission": "dataproc.clusters.create",
+         "granted": true,
+         "resourceAttributes": {}
+       }
+     ],
+     "resourceName": "projects/my-project/regions/global/clusters/test-dataproc-cluster",
+     "request": {
+       "projectId": "my-project",
+       "cluster": {
+         "config": {
+           "workerConfig": {
+             "diskConfig": {
+               "bootDiskSizeGb": 15,
+               "bootDiskType": "pd-standard"
+             },
+             "numInstances": 2,
+             "machineTypeUri": "n1-standard-1"
+           },
+           "masterConfig": {
+             "machineTypeUri": "n1-standard-1",
+             "diskConfig": {
+               "bootDiskType": "pd-standard",
+               "bootDiskSizeGb": 15
+             },
+             "numInstances": 1
+           },
+           "secondaryWorkerConfig": {
+             "isPreemptible": true
+           },
+           "gceClusterConfig": {
+             "internalIpOnly": true,
+             "zoneUri": "us-east1-b",
+             "subnetworkUri": "default"
+           },
+           "softwareConfig": {
+             "imageVersion": "1.3-deb9"
+           }
+         },
+         "clusterName": "test-dataproc-cluster",
+         "projectId": "my-project"
+       },
+       "region": "global",
+       "@type": "type.googleapis.com/google.cloud.dataproc.v1beta2.CreateClusterRequest"
+     },
+     "resourceLocation": {
+       "currentLocations": [
+         "global"
+       ]
+     }
+   },
+   "insertId": "abc2def5gh",
+   "resource": {
+     "type": "cloud_dataproc_cluster",
+     "labels": {
+       "project_id": "my-project",
+       "cluster_name": "test-dataproc-cluster",
+       "region": "global",
+       "cluster_uuid": "123a45a6-f7f8-901c-23e4-5dfb67db8f90"
+     }
+   },
+   "timestamp": "1970-01-01T00:00:00.000Z",
+   "severity": "NOTICE",
+   "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+   "operation": {
+     "id": "projects/my-project/regions/global/operations/abcde10f-72g4-4hi7-g694-5bd27kl08mno",
+     "producer": "dataproc.googleapis.com",
+     "first": true
+   },
+   "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+}

--- a/tests/data/gke-cluster-update.json
+++ b/tests/data/gke-cluster-update.json
@@ -1,0 +1,64 @@
+{
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {
+            "principalEmail": "example@example.com"
+        },
+        "requestMetadata": {
+            "callerIp": "0.0.0.0",
+            "callerSuppliedUserAgent": "curl",
+            "requestAttributes": {
+                "time": "2000-01-01T00:00:01.579869181Z",
+                "auth": {}
+            },
+            "destinationAttributes": {}
+        },
+        "serviceName": "container.googleapis.com",
+        "methodName": "google.container.v1.ClusterManager.SetLegacyAbac",
+        "authorizationInfo": [
+            {
+                "permission": "container.clusters.update",
+                "granted": true,
+                "resourceAttributes": {}
+            }
+        ],
+        "resourceName": "projects/example-project/zones/europe-west4-a/clusters/example-cluster",
+        "request": {
+            "name": "projects/example-project/locations/europe-west4-a/clusters/example-cluster",
+            "enabled": true,
+            "@type": "type.googleapis.com/google.container.v1alpha1.SetLegacyAbacRequest"
+        },
+        "response": {
+            "status": "RUNNING",
+            "name": "operation-1-1",
+            "selfLink": "https://container.googleapis.com/v1alpha1/projects/example-project/zones/europe-west4-a/operations/operation-1-1",
+            "targetLink": "https://container.googleapis.com/v1alpha1/projects/example-project/zones/europe-west4-a/clusters/example-cluster",
+            "@type": "type.googleapis.com/google.container.v1alpha1.Operation",
+            "operationType": "UPDATE_CLUSTER",
+            "startTime": "2000-01-01T00:00:01.580331131Z"
+        },
+        "resourceLocation": {
+            "currentLocations": [
+                "europe-west4-a"
+            ]
+        }
+    },
+    "insertId": "aaabbb",
+    "resource": {
+        "type": "gke_cluster",
+        "labels": {
+            "project_id": "example-project",
+            "cluster_name": "example-cluster",
+            "location": "europe-west4-a"
+        }
+    },
+    "timestamp": "2000-01-01T00:00:01.594543941Z",
+    "severity": "INFO",
+    "logName": "projects/example-project/logs/cloudaudit.googleapis.com%2Fdata_access",
+    "operation": {
+        "id": "operation-1-1",
+        "producer": "container.googleapis.com",
+        "first": true
+    },
+    "receiveTimestamp": "2000-01-01T00:00:01.264355708Z"
+}

--- a/tests/data/gke-nodepool-set.json
+++ b/tests/data/gke-nodepool-set.json
@@ -1,0 +1,68 @@
+{
+    "protoPayload": {
+        "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+        "authenticationInfo": {
+            "principalEmail": "example@example.com"
+        },
+        "requestMetadata": {
+            "callerIp": "0.0.0.0",
+            "callerSuppliedUserAgent": "curl",
+            "requestAttributes": {
+                "time": "2000-01-01T00:00:01.654806738Z",
+                "auth": {}
+            },
+            "destinationAttributes": {}
+        },
+        "serviceName": "container.googleapis.com",
+        "methodName": "google.container.v1.ClusterManager.SetNodePoolManagement",
+        "authorizationInfo": [
+            {
+                "permission": "container.clusters.update",
+                "granted": true,
+                "resourceAttributes": {}
+            }
+        ],
+        "resourceName": "projects/example-project/zones/europe-west4-a/clusters/example-cluster/nodePools/example-pool",
+        "request": {
+            "name": "projects/example-project/locations/europe-west4-a/clusters/example-cluster/nodePools/example-pool",
+            "management": {
+                "autoRepair": true,
+                "autoUpgrade": true
+            },
+            "@type": "type.googleapis.com/google.container.v1alpha1.SetNodePoolManagementRequest"
+        },
+        "response": {
+            "status": "RUNNING",
+            "name": "operation-1-1",
+            "selfLink": "https://container.googleapis.com/v1alpha1/projects/example-project/zones/europe-west4-a/operations/operation-1-1",
+            "targetLink": "https://container.googleapis.com/v1alpha1/projects/example-project/zones/europe-west4-a/clusters/example-cluster/nodePools/example-pool",
+            "@type": "type.googleapis.com/google.container.v1alpha1.Operation",
+            "operationType": "SET_NODE_POOL_MANAGEMENT",
+            "startTime": "2000-01-01T00:00:01.655021234Z"
+        },
+        "resourceLocation": {
+            "currentLocations": [
+                "europe-west4-a"
+            ]
+        }
+    },
+    "insertId": "1",
+    "resource": {
+        "type": "gke_nodepool",
+        "labels": {
+            "project_id": "example-project",
+            "nodepool_name": "example-pool",
+            "cluster_name": "example-cluster",
+            "location": "europe-west4-a"
+        }
+    },
+    "timestamp": "2000-01-01T00:00:01.673796417Z",
+    "severity": "INFO",
+    "logName": "projects/example-project/logs/cloudaudit.googleapis.com%2Fdata_access",
+    "operation": {
+        "id": "operation-1-1",
+        "producer": "container.googleapis.com",
+        "first": true
+    },
+    "receiveTimestamp": "2000-01-01T00:00:01.400552358Z"
+}

--- a/tests/data/memorystore-redis.json
+++ b/tests/data/memorystore-redis.json
@@ -1,0 +1,69 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "example@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "::1",
+      "callerSuppliedUserAgent": "",
+      "requestAttributes": {
+        "time": "2021-04-06T02:06:28.480329145Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "redis.googleapis.com",
+    "methodName": "google.cloud.redis.v1.CloudRedis.CreateInstance",
+    "authorizationInfo": [
+      {
+        "resource": "projects/example-project/locations/us-central1/instances/test-instance",
+        "permission": "redis.instances.create",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "projects/example-project/locations/us-central1/instances/test-instance",
+    "request": {
+      "instance_id": "test-instance",
+      "instance": {
+        "auth_enabled": false,
+        "redis_version": "REDIS_5_0",
+        "authorized_network": "projects/example-project/global/networks/datalab-network",
+        "connect_mode": "PRIVATE_SERVICE_ACCESS",
+        "tier": "BASIC",
+        "memory_size_gb": 1,
+        "transit_encryption_mode": "SERVER_AUTHENTICATION"
+      },
+      "@type": "type.googleapis.com/google.cloud.redis.v1.CreateInstanceRequest",
+      "parent": "projects/example-project/locations/us-central1"
+    },
+    "response": {
+      "@type": "type.googleapis.com/google.longrunning.Operation"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-central1"
+      ]
+    }
+  },
+  "insertId": "teysgnc46q",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "service": "redis.googleapis.com",
+      "method": "google.cloud.redis.v1.CloudRedis.CreateInstance",
+      "project_id": "example-project"
+    }
+  },
+  "timestamp": "2021-04-06T02:06:29.528016514Z",
+  "severity": "NOTICE",
+  "logName": "projects/example-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "projects/example-project/locations/us-central1/operations/operation-1617674788493-5bf4443215a51-e11da1a5-c08be436",
+    "producer": "redis.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-04-06T02:06:30.057990562Z"
+}

--- a/tests/data/project_get_iam.json
+++ b/tests/data/project_get_iam.json
@@ -1,0 +1,48 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "test-user@lab.cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "76.98.160.101",
+      "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:90.0) Gecko/20100101 Firefox/90.0,gzip(gfe)",
+      "requestAttributes": {},
+      "destinationAttributes": {}
+    },
+    "serviceName": "cloudresourcemanager.googleapis.com",
+    "methodName": "GetIamPolicy",
+    "authorizationInfo": [
+      {
+        "resource": "projects/cd-np-test1",
+        "permission": "resourcemanager.projects.getIamPolicy",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "cloudresourcemanager.googleapis.com",
+          "name": "projects/cd-np-test1",
+          "type": "cloudresourcemanager.googleapis.com/Project"
+        }
+      }
+    ],
+    "resourceName": "projects/cd-np-test1",
+    "request": {
+      "@type": "type.googleapis.com/google.iam.v1.GetIamPolicyRequest",
+      "resource": "cd-np-test1",
+      "options": {
+        "requestedPolicyVersion": 3
+      }
+    }
+  },
+  "insertId": "-kt15ird337w",
+  "resource": {
+    "type": "project",
+    "labels": {
+      "project_id": "cd-np-test1"
+    }
+  },
+  "timestamp": "2021-07-27T03:29:39.945759Z",
+  "severity": "INFO",
+  "logName": "projects/cd-np-test1/logs/cloudaudit.googleapis.com%2Fdata_access",
+  "receiveTimestamp": "2021-07-27T03:29:40.090753959Z"
+}

--- a/tests/data/project_set_iam.json
+++ b/tests/data/project_set_iam.json
@@ -1,0 +1,116 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "test-user@lab.cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "76.98.160.101",
+      "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:90.0) Gecko/20100101 Firefox/90.0,gzip(gfe)",
+      "requestAttributes": {},
+      "destinationAttributes": {}
+    },
+    "serviceName": "cloudresourcemanager.googleapis.com",
+    "methodName": "SetIamPolicy",
+    "authorizationInfo": [
+      {
+        "resource": "projects/cd-np-test1",
+        "permission": "resourcemanager.projects.setIamPolicy",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "cloudresourcemanager.googleapis.com",
+          "name": "projects/cd-np-test1",
+          "type": "cloudresourcemanager.googleapis.com/Project"
+        }
+      },
+      {
+        "resource": "projects/cd-np-test1",
+        "permission": "resourcemanager.projects.setIamPolicy",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "cloudresourcemanager.googleapis.com",
+          "name": "projects/cd-np-test1",
+          "type": "cloudresourcemanager.googleapis.com/Project"
+        }
+      }
+    ],
+    "resourceName": "projects/cd-np-test1",
+    "serviceData": {
+      "@type": "type.googleapis.com/google.iam.v1.logging.AuditData",
+      "policyDelta": {
+        "bindingDeltas": [
+          {
+            "action": "REMOVE",
+            "role": "roles/compute.admin",
+            "member": "serviceAccount:compute-full@cd-np-test1.iam.gserviceaccount.com"
+          }
+        ]
+      }
+    },
+    "request": {
+      "@type": "type.googleapis.com/google.iam.v1.SetIamPolicyRequest",
+      "policy": {
+        "etag": "BGxQGM=",
+        "bindings": [
+          {
+            "members": [
+              "serviceAccount:1234123123-compute@developer.gserviceaccount.com"
+            ],
+            "role": "roles/compute.admin"
+          }
+        ],
+        "auditConfigs": [
+          {
+            "auditLogConfigs": [
+              {
+                "logType": "ADMIN_READ"
+              },
+              {
+                "logType": "DATA_WRITE"
+              },
+              {
+                "logType": "DATA_READ"
+              }
+            ],
+            "service": "allServices"
+          }
+        ]
+      },
+      "resource": "cd-np-test1"
+    },
+    "response": {
+      "bindings": [
+      ],
+      "@type": "type.googleapis.com/google.iam.v1.Policy",
+      "etag": "BwXIEnsd74U=",
+      "auditConfigs": [
+        {
+          "auditLogConfigs": [
+            {
+              "logType": "ADMIN_READ"
+            },
+            {
+              "logType": "DATA_WRITE"
+            },
+            {
+              "logType": "DATA_READ"
+            }
+          ],
+          "service": "allServices"
+        }
+      ]
+    }
+  },
+  "insertId": "bxxka8e1doza",
+  "resource": {
+    "type": "project",
+    "labels": {
+      "project_id": "cd-np-test1"
+    }
+  },
+  "timestamp": "2021-07-27T03:29:43.406122Z",
+  "severity": "NOTICE",
+  "logName": "projects/cd-np-test1/logs/cloudaudit.googleapis.com%2Factivity",
+  "receiveTimestamp": "2021-07-27T03:29:44.765683992Z"
+}

--- a/tests/data/pubsub-subscription-set-iam-policy.json
+++ b/tests/data/pubsub-subscription-set-iam-policy.json
@@ -1,0 +1,66 @@
+{
+  "insertId": "1q5m3sjd1qfd",
+  "logName": "projects/fake-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "joe.ceresini@cleardata.com"
+    },
+    "authorizationInfo": [
+      {
+        "granted": true,
+        "permission": "pubsub.subscriptions.setIamPolicy",
+        "resource": "projects/fake-project/subscriptions/test-subscription",
+        "resourceAttributes": {}
+      }
+    ],
+    "methodName": "google.iam.v1.IAMPolicy.SetIamPolicy",
+    "request": {
+      "@type": "type.googleapis.com/google.iam.v1.SetIamPolicyRequest",
+      "policy": {
+        "bindings": [
+          {
+            "members": [
+              "user:joe.ceresini@admin.cleardata.com"
+            ],
+            "role": "roles/viewer"
+          }
+        ],
+        "etag": "BwWHN0DS61A="
+      },
+      "resource": "projects/fake-project/subscriptions/test-subscription"
+    },
+    "requestMetadata": {
+      "callerIp": "203.0.113.126",
+      "callerSuppliedUserAgent": "x",
+      "destinationAttributes": {},
+      "requestAttributes": {
+        "auth": {},
+        "time": "2019-04-23T19:04:26.016573368Z"
+      }
+    },
+    "resourceName": "projects/fake-project/subscriptions/test-subscription",
+    "response": {
+      "@type": "type.googleapis.com/google.iam.v1.Policy",
+      "bindings": [
+        {
+          "members": [
+            "user:some.user@example.com"
+          ],
+          "role": "roles/viewer"
+        }
+      ],
+      "etag": "BwWHN0D3BPE="
+    },
+    "serviceName": "pubsub.googleapis.com"
+  },
+  "receiveTimestamp": "2019-04-23T19:04:26.998833327Z",
+  "resource": {
+    "labels": {
+      "project_id": "fake-project",
+      "subscription_id": "projects/fake-project/subscriptions/test-subscription"
+    },
+    "type": "pubsub_subscription"
+  },
+  "timestamp": "1970-01-01T00:00:00.000000000Z"
+}

--- a/tests/data/pubsub-topic-set-iam-policy.json
+++ b/tests/data/pubsub-topic-set-iam-policy.json
@@ -1,0 +1,67 @@
+{
+  "insertId": "x0yt3bc1ma",
+  "logName": "projects/fake-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "some.user@example.com"
+    },
+    "authorizationInfo": [
+      {
+        "granted": true,
+        "permission": "pubsub.topics.setIamPolicy",
+        "resource": "projects/fake-project/topics/test-topic",
+        "resourceAttributes": {}
+      }
+    ],
+    "methodName": "google.iam.v1.IAMPolicy.SetIamPolicy",
+    "request": {
+      "@type": "type.googleapis.com/google.iam.v1.SetIamPolicyRequest",
+      "policy": {
+        "bindings": [
+          {
+            "members": [
+              "allUsers"
+            ],
+            "role": "roles/pubsub.viewer"
+          }
+        ],
+        "etag": "ACAB"
+      },
+      "resource": "projects/fake-project/topics/test-topic"
+    },
+    "requestMetadata": {
+      "callerIp": "203.0.113.42",
+      "callerSuppliedUserAgent": "x",
+      "destinationAttributes": {},
+      "requestAttributes": {
+        "auth": {},
+        "time": "2019-04-23T17:42:58.838042417Z"
+      }
+    },
+    "resourceName": "projects/fake-project/topics/test-topic",
+    "response": {
+      "@type": "type.googleapis.com/google.iam.v1.Policy",
+      "bindings": [
+        {
+          "members": [
+            "allUsers"
+          ],
+          "role": "roles/pubsub.viewer"
+        }
+      ],
+      "etag": "BwWHNh2py/k="
+    },
+    "serviceName": "pubsub.googleapis.com"
+  },
+  "receiveTimestamp": "2019-04-23T17:42:59.421688776Z",
+  "resource": {
+    "labels": {
+      "project_id": "fake-project",
+      "topic_id": "projects/fake-project/topics/test-topic"
+    },
+    "type": "pubsub_topic"
+  },
+  "severity": "NOTICE",
+  "timestamp": "2019-04-23T17:42:58.817353433Z"
+}

--- a/tests/data/servicemanagement-activate-service.json
+++ b/tests/data/servicemanagement-activate-service.json
@@ -1,0 +1,77 @@
+ {
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0:0:0:0:0:0:0:0",
+      "callerSuppliedUserAgent": "unknown"
+    },
+    "serviceName": "servicemanagement.googleapis.com",
+    "methodName": "google.api.servicemanagement.v0.ServiceManager.ActivateServices",
+    "authorizationInfo": [
+      {
+        "resource": "services/calendar-json.googleapis.com",
+        "permission": "servicemanagement.services.bind",
+        "granted": true
+      },
+      {
+        "resource": "projectnumbers/000000000000/services/-",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "projectnumbers/000000000000/services/-",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "services/calendar-json.googleapis.com",
+        "permission": "servicemanagement.services.bindAll"
+      },
+      {
+        "resource": "services/calendar-json.googleapis.com/consumers/000000000000",
+        "permission": "serviceconsumermanagement.consumers.enable"
+      }
+    ],
+    "resourceName": "projects/000000000000/services/[calendar-json.googleapis.com]",
+    "request": {
+      "consumerProjectId": "my-project",
+      "serviceNames": [
+        "calendar-json.googleapis.com"
+      ],
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.ActivateServicesRequest"
+    },
+    "response": {
+      "settings": [
+        {
+          "serviceName": "calendar-json.googleapis.com",
+          "usageSettings": {
+            "consumerEnableStatus": "ENABLED"
+          }
+        }
+      ],
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.ActivateServicesResponse"
+    }
+  },
+  "insertId": "-dvbh0bc0w0",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "service": "servicemanagement.googleapis.com",
+      "method": "google.api.servicemanagement.v0.ServiceManager.ActivateServices",
+      "project_id": "my-project"
+    }
+  },
+  "timestamp": "1970-01-01T00:00:00.000000000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operations/acf.00f000a0-0e00-0bc0-0000-000a0000ce00",
+    "producer": "servicemanagement.googleapis.com",
+    "last": true
+  },
+  "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+}

--- a/tests/data/servicemanagement-deactivate-service.json
+++ b/tests/data/servicemanagement-deactivate-service.json
@@ -1,0 +1,66 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0:0:0:0:0:0:0:0",
+      "callerSuppliedUserAgent": "unknown"
+    },
+    "serviceName": "servicemanagement.googleapis.com",
+    "methodName": "google.api.servicemanagement.v0.ServiceManager.DeactivateServices",
+    "authorizationInfo": [
+      {
+        "resource": "projectnumbers/000000000000/services/-",
+        "permission": "serviceusage.services.disable",
+        "granted": true
+      },
+      {
+        "resource": "services/zync.googleapis.com",
+        "permission": "servicemanagement.services.bindAll"
+      },
+      {
+        "resource": "services/zync.googleapis.com/consumers/000000000000",
+        "permission": "serviceconsumermanagement.consumers.disable"
+      }
+    ],
+    "resourceName": "projects/000000000000/services/[zync.googleapis.com]",
+    "request": {
+      "consumerProjectId": "my-project",
+      "serviceNames": [
+        "zync.googleapis.com"
+      ],
+      "errorWhenDeactivatingDependentServices": true,
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.DeactivateServicesRequest"
+    },
+    "response": {
+      "settings": [
+        {
+          "serviceName": "zync.googleapis.com",
+          "usageSettings": {}
+        }
+      ],
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.DeactivateServicesResponse"
+    }
+  },
+  "insertId": "-lwk00yc0qk",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "service": "servicemanagement.googleapis.com",
+      "method": "google.api.servicemanagement.v0.ServiceManager.DeactivateServices",
+      "project_id": "my-project"
+    }
+  },
+  "timestamp": "1970-01-01T00:00:00.000000000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operations/acf.00dff0e0-ae0e-00fd-a0b0-cd00bb00b00d",
+    "producer": "servicemanagement.googleapis.com",
+    "last": true
+  },
+  "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+}

--- a/tests/data/servicemanagement-disable-service.json
+++ b/tests/data/servicemanagement-disable-service.json
@@ -1,0 +1,57 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0:0:0:0:0:0:0:0",
+      "callerSuppliedUserAgent": "unknown"
+    },
+    "serviceName": "servicemanagement.googleapis.com",
+    "methodName": "google.api.servicemanagement.v0.ServiceManager.DisableService",
+    "authorizationInfo": [
+      {
+        "resource": "projectnumbers/000000000000/services/-",
+        "permission": "serviceusage.services.disable",
+        "granted": true
+      },
+      {
+        "resource": "services/youtubereporting.googleapis.com",
+        "permission": "servicemanagement.services.bindAll"
+      },
+      {
+        "resource": "services/youtubereporting.googleapis.com/consumers/000000000000",
+        "permission": "serviceconsumermanagement.consumers.disable"
+      }
+    ],
+    "resourceName": "projects/000000000000/services/youtubereporting.googleapis.com",
+    "request": {
+      "serviceName": "youtubereporting.googleapis.com",
+      "consumerId": "project:my-project",
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.DisableServiceRequest"
+    },
+    "response": {
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.DisableServiceResponse"
+    }
+  },
+  "insertId": "-gmzpb0c0v0",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "method": "google.api.servicemanagement.v0.ServiceManager.DisableService",
+      "project_id": "my-project",
+      "service": "servicemanagement.googleapis.com"
+    }
+  },
+  "timestamp": "1970-01-01T00:00:00.000000000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operations/acf.b00c0000-00c0-00ff-000c-00db0cba00fb",
+    "producer": "servicemanagement.googleapis.com",
+    "last": true
+  },
+  "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+}

--- a/tests/data/servicemanagement-enable-service.json
+++ b/tests/data/servicemanagement-enable-service.json
@@ -1,0 +1,67 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0:0:0:0:0:0:0:0",
+      "callerSuppliedUserAgent": "unknown"
+    },
+    "serviceName": "servicemanagement.googleapis.com",
+    "methodName": "google.api.servicemanagement.v0.ServiceManager.EnableService",
+    "authorizationInfo": [
+      {
+        "resource": "services/youtubeadsreach.googleapis.com",
+        "permission": "servicemanagement.services.bind",
+        "granted": true
+      },
+      {
+        "resource": "projectnumbers/000000000000/services/-",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "projectnumbers/000000000000/services/-",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "services/youtubeadsreach.googleapis.com",
+        "permission": "servicemanagement.services.bindAll"
+      },
+      {
+        "resource": "services/youtubeadsreach.googleapis.com/consumers/000000000000",
+        "permission": "serviceconsumermanagement.consumers.enable"
+      }
+    ],
+    "resourceName": "projects/000000000000/services/youtubeadsreach.googleapis.com",
+    "request": {
+      "serviceName": "youtubeadsreach.googleapis.com",
+      "consumerId": "project:my-project",
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.EnableServiceRequest"
+    },
+    "response": {
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.EnableServiceResponse"
+    }
+  },
+  "insertId": "0e0000c0z0",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "method": "google.api.servicemanagement.v0.ServiceManager.EnableService",
+      "project_id": "my-project",
+      "service": "servicemanagement.googleapis.com"
+    }
+  },
+  "timestamp": "1970-01-01T00:00:00.000000000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operations/acf.dbfd000c-a0ff-0000-0d00-0e00f0fc00ad",
+    "producer": "servicemanagement.googleapis.com",
+    "last": true
+  },
+  "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+}

--- a/tests/data/serviceusage-batchenable.json
+++ b/tests/data/serviceusage-batchenable.json
@@ -1,0 +1,74 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "00.00.000.000",
+      "callerSuppliedUserAgent": "Mozilla/0.0 (Macintosh; Intel Mac OS X 00.00; rv:00.0) Gecko/00000000 Firefox/00.0,gzip(gfe)"
+    },
+    "serviceName": "serviceusage.googleapis.com",
+    "methodName": "google.api.serviceusage.v0.ServiceUsage.BatchEnableServices",
+    "authorizationInfo": [
+      {
+        "resource": "projectnumbers/000000000000/services/toolresults.googleapis.com",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "services/toolresults.googleapis.com",
+        "permission": "servicemanagement.services.bind",
+        "granted": true
+      },
+      {
+        "resource": "projectnumbers/000000000000/services/travelpartner.googleapis.com",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "services/travelpartner.googleapis.com",
+        "permission": "servicemanagement.services.bind",
+        "granted": true
+      },
+      {
+        "resource": "projectnumbers/000000000000/services/tpu.googleapis.com",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "services/tpu.googleapis.com",
+        "permission": "servicemanagement.services.bind",
+        "granted": true
+      }
+    ],
+    "resourceName": "projects/my-project/services",
+    "request": {
+      "@type": "type.googleapis.com/google.api.serviceusage.v0.BatchEnableServicesRequest",
+      "parent": "projects/my-project",
+      "serviceIds": [
+        "toolresults.googleapis.com",
+        "travelpartner.googleapis.com",
+        "tpu.googleapis.com"
+      ]
+    }
+  },
+  "insertId": "0pbj0omc0al",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "service": "serviceusage.googleapis.com",
+      "method": "google.api.serviceusage.v0.ServiceUsage.BatchEnableServices",
+      "project_id": "my-project"
+    }
+  },
+  "timestamp": "1970-01-01T00:00:00.000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operations/acf.000000f0-cbf0-00b0-0e00-d000b000b00b",
+    "producer": "serviceusage.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+}

--- a/tests/data/serviceusage-disable.json
+++ b/tests/data/serviceusage-disable.json
@@ -1,0 +1,56 @@
+{
+ "protoPayload": {
+   "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+   "status": {},
+   "authenticationInfo": {
+     "principalEmail": "user@example.com"
+   },
+   "requestMetadata": {
+     "callerIp": "0:0:0:0:0:0:0:0",
+     "callerSuppliedUserAgent": "unknown"
+   },
+   "serviceName": "serviceusage.googleapis.com",
+   "methodName": "google.api.serviceusage.v0.ServiceUsage.DisableService",
+   "authorizationInfo": [
+     {
+       "resource": "projectnumbers/000000000000/services/zync.googleapis.com",
+       "permission": "serviceusage.services.disable",
+       "granted": true
+     }
+   ],
+   "resourceName": "projects/my-project/services/zync.googleapis.com",
+   "request": {
+     "name": "projects/my-project/services/zync.googleapis.com",
+     "@type": "type.googleapis.com/google.api.serviceusage.v0.DisableServiceRequest"
+   },
+   "response": {
+     "service": {
+       "name": "projects/000000000000/services/zync.googleapis.com",
+       "config": {
+         "name": "zync.googleapis.com",
+         "title": "Zync Render API"
+       },
+       "state": "DISABLED"
+     },
+     "@type": "type.googleapis.com/google.api.serviceusage.v0.DisableServiceResponse"
+   }
+ },
+ "insertId": "ftwjblc00c",
+ "resource": {
+   "type": "audited_resource",
+   "labels": {
+     "method": "google.api.serviceusage.v0.ServiceUsage.DisableService",
+     "project_id": "my-project",
+     "service": "serviceusage.googleapis.com"
+   }
+ },
+ "timestamp": "1970-01-01T00:00:00.000000000Z",
+ "severity": "NOTICE",
+ "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+ "operation": {
+   "id": "operations/acf.00000eb0-c0da-000e-b000-00eca0000fc0",
+   "producer": "serviceusage.googleapis.com",
+   "last": true
+ },
+ "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+ }

--- a/tests/data/serviceusage-enable.json
+++ b/tests/data/serviceusage-enable.json
@@ -1,0 +1,61 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0:0:0:0:0:0:0:0",
+      "callerSuppliedUserAgent": "unknown"
+    },
+    "serviceName": "serviceusage.googleapis.com",
+    "methodName": "google.api.serviceusage.v0.ServiceUsage.EnableService",
+    "authorizationInfo": [
+      {
+        "resource": "projectnumbers/000000000000/services/youtubereporting.googleapis.com",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "services/youtubereporting.googleapis.com",
+        "permission": "servicemanagement.services.bind",
+        "granted": true
+      }
+    ],
+    "resourceName": "projects/my-project/services/youtubereporting.googleapis.com",
+    "request": {
+      "name": "projects/my-project/services/youtubereporting.googleapis.com",
+      "@type": "type.googleapis.com/google.api.serviceusage.v0.EnableServiceRequest"
+    },
+    "response": {
+      "service": {
+        "name": "projects/000000000000/services/youtubereporting.googleapis.com",
+        "config": {
+          "name": "youtubereporting.googleapis.com",
+          "title": "YouTube Reporting API"
+        },
+        "state": "ENABLED"
+      },
+      "@type": "type.googleapis.com/google.api.serviceusage.v0.EnableServiceResponse"
+    }
+  },
+  "insertId": "-t0cikkc0lq",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "service": "serviceusage.googleapis.com",
+      "method": "google.api.serviceusage.v0.ServiceUsage.EnableService",
+      "project_id": "my-project"
+    }
+  },
+  "timestamp": "1970-01-01T00:00:00.000000000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operations/acf.b0ee00e0-000c-0f00-0d0b-ae0dafb0fb00",
+    "producer": "serviceusage.googleapis.com",
+    "last": true
+  },
+  "receiveTimestamp": "1970-01-01T00:00:00.000000000Z"
+}

--- a/tests/data/storage_bucket_delete.json
+++ b/tests/data/storage_bucket_delete.json
@@ -1,0 +1,53 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "test-user@lab.cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "76.98.160.101",
+      "callerSuppliedUserAgent": "apitools Python/3.9.6 gsutil/4.62 (darwin) analytics/disabled interactive/True command/rm google-cloud-sdk/341.0.0,gzip(gfe)",
+      "requestAttributes": {
+        "time": "2021-07-27T03:25:33.648354953Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "storage.googleapis.com",
+    "methodName": "storage.buckets.delete",
+    "authorizationInfo": [
+      {
+        "resource": "projects/_/buckets/test-bucket",
+        "permission": "storage.buckets.delete",
+        "granted": true,
+        "resourceAttributes": {}
+      },
+      {
+        "resource": "projects/_/buckets/test-bucket",
+        "permission": "storage.buckets.getIamPolicy",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "projects/_/buckets/test-bucket",
+    "resourceLocation": {
+      "currentLocations": [
+        "us"
+      ]
+    }
+  },
+  "insertId": "-mghe2ce96y5q",
+  "resource": {
+    "type": "gcs_bucket",
+    "labels": {
+      "location": "us",
+      "bucket_name": "test-bucket",
+      "project_id": "cd-np-test1"
+    }
+  },
+  "timestamp": "2021-07-27T03:25:33.641913409Z",
+  "severity": "NOTICE",
+  "logName": "projects/cd-np-test1/logs/cloudaudit.googleapis.com%2Factivity",
+  "receiveTimestamp": "2021-07-27T03:25:34.635772082Z"
+}

--- a/tests/data/storage_bucket_update.json
+++ b/tests/data/storage_bucket_update.json
@@ -1,0 +1,47 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "test-user@lab.cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "203.0.113.54",
+      "callerSuppliedUserAgent": "apitools Python/3.9.6 gsutil/4.62 (darwin) analytics/disabled interactive/True command/versioning google-cloud-sdk/341.0.0,gzip(gfe)",
+      "requestAttributes": {
+        "time": "2021-07-27T03:21:15.112831295Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "storage.googleapis.com",
+    "methodName": "storage.buckets.update",
+    "authorizationInfo": [
+      {
+        "resource": "projects/_/buckets/test-bucket",
+        "permission": "storage.buckets.update",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "projects/_/buckets/test-bucket",
+    "resourceLocation": {
+      "currentLocations": [
+        "us"
+      ]
+    }
+  },
+  "insertId": "yf4uxaec89sz",
+  "resource": {
+    "type": "gcs_bucket",
+    "labels": {
+      "location": "us",
+      "bucket_name": "test-bucket",
+      "project_id": "cd-np-test1"
+    }
+  },
+  "timestamp": "2021-07-27T03:21:15.106547949Z",
+  "severity": "NOTICE",
+  "logName": "projects/cd-np-test1/logs/cloudaudit.googleapis.com%2Factivity",
+  "receiveTimestamp": "2021-07-27T03:21:15.915032759Z"
+}

--- a/tests/test_extractors_gcp_auditlogs.py
+++ b/tests/test_extractors_gcp_auditlogs.py
@@ -1,0 +1,134 @@
+import json
+import os
+
+import pytest
+
+from rpe.exceptions import ExtractorException
+from rpe.extractors.gcp_auditlogs import GCPAuditLog
+from rpe.resources.gcp import GcpComputeDisk
+
+
+def get_test_data(filename):
+    '''Load json data from the tests dir'''
+    p = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        'data',
+        filename,
+    )
+
+    with open(p) as f:
+        return json.load(f)
+
+
+# parameters for testing logs that should return a single asset
+test_single_asset_log_params = [
+    # filename, expected_resource_type, expected_operation_type, expected_resource_name
+    ("app-engine-debug.json", "appengine.googleapis.com/Instance", "update", "aef-default-test-instance"),
+    ("bq-ds-set-iam-policy.json", "bigquery.googleapis.com/Dataset", "update", "wooo"),
+    ("bigtable-set-iam-policy.json", "bigtableadmin.googleapis.com/Instance", "update", "example-instance"),
+    ("pubsub-subscription-set-iam-policy.json", "pubsub.googleapis.com/Subscription", "update", "test-subscription"),
+    ("pubsub-topic-set-iam-policy.json", "pubsub.googleapis.com/Topic", "update", "test-topic"),
+
+    # CloudSQL logs are inconsistent. See https://issuetracker.google.com/issues/137629452
+    ("cloudsql-resource.labels.json", "sqladmin.googleapis.com/Instance", "create", "test-instance"),
+    ("cloudsql-protoPayload.request.body.json", "sqladmin.googleapis.com/Instance", "create", "test-instance"),
+    (
+        "cloudsql-protoPayload.request.resource.instanceName.instanceId.json", "sqladmin.googleapis.com/Instance",
+        "create", "test-instance"
+    ),
+    ("cloudfunctions-set-iam-policy.json", "cloudfunctions.googleapis.com/CloudFunction", "update", "example_function"),
+    ("compute_networks_insert_1.json", "compute.googleapis.com/Network", "create", "xyz"),
+    ("compute_networks_insert_2.json", "compute.googleapis.com/Network", "create", "xyzcli"),
+    ("compute_networks_insert_3.json", "compute.googleapis.com/Network", "update", "datalab-network"),
+    ("compute-subnetworks-enable-flow-logs.json", "compute.googleapis.com/Subnetwork", "update", "example"),
+    ("compute-subnetworks-set-private-ip-google-access.json", "compute.googleapis.com/Subnetwork", "update", "example"),
+    ("compute-firewalls-enable-logs-policy.json", "compute.googleapis.com/Firewall", "create", "test-firewall"),
+    ("dataproc_createcluster.json", "dataproc.googleapis.com/Cluster", "create", "test-dataproc-cluster"),
+    ("datafusion-create-instance.json", "datafusion.googleapis.com/Instance", "create", "test-instance"),
+    ("datafusion-update-instance.json", "datafusion.googleapis.com/Instance", "update", "test-instance"),
+    ("gke-cluster-update.json", "container.googleapis.com/Cluster", "update", "example-cluster"),
+    ("gke-nodepool-set.json", "container.googleapis.com/NodePool", "update", "example-pool"),
+    ("project_get_iam.json", "cloudresourcemanager.googleapis.com/Project", "read", "cd-np-test1"),
+    ("project_set_iam.json", "cloudresourcemanager.googleapis.com/Project", "update", "cd-np-test1"),
+    (
+        "servicemanagement-enable-service.json", "serviceusage.googleapis.com/Service", "update",
+        "youtubeadsreach.googleapis.com"
+    ),
+    (
+        "servicemanagement-disable-service.json", "serviceusage.googleapis.com/Service", "update",
+        "youtubereporting.googleapis.com"
+    ),
+    (
+        "servicemanagement-activate-service.json", "serviceusage.googleapis.com/Service", "update",
+        "calendar-json.googleapis.com"
+    ),
+    (
+        "servicemanagement-deactivate-service.json", "serviceusage.googleapis.com/Service", "update",
+        "zync.googleapis.com"
+    ),
+    ("serviceusage-enable.json", "serviceusage.googleapis.com/Service", "update", "youtubereporting.googleapis.com"),
+    ("serviceusage-disable.json", "serviceusage.googleapis.com/Service", "update", "zync.googleapis.com"),
+    ("storage_bucket_delete.json", "storage.googleapis.com/Bucket", "delete", "test-bucket"),
+    ("storage_bucket_update.json", "storage.googleapis.com/Bucket", "update", "test-bucket"),
+    ("dataflow-job-step.json", "dataflow.googleapis.com/Job", "create", "job-id"),
+    ("memorystore-redis.json", "redis.googleapis.com/Instance", "create", "test-instance"),
+]
+
+test_log_resource_count_params = [
+    ("serviceusage-batchenable.json", 3),
+    ("compute-hardened-images.json", 3),
+]
+
+
+@pytest.mark.parametrize(
+    "filename,expected_resource_type,expected_operation_type,expected_resource_name", test_single_asset_log_params
+)
+def test_single_asset_log_messages(filename, expected_resource_type, expected_operation_type, expected_resource_name):
+    log_message = get_test_data(filename)
+
+    extracted = GCPAuditLog.extract(log_message)
+
+    assert len(extracted.resources) == 1
+    resource = extracted.resources[0]
+
+    assert resource.resource_type == expected_resource_type
+    assert extracted.metadata.operation == expected_operation_type
+    assert resource.resource_name == expected_resource_name
+
+
+@pytest.mark.parametrize("filename,expected_resource_count", test_log_resource_count_params)
+def test_log_resource_count(filename, expected_resource_count):
+    log_message = get_test_data(filename)
+
+    extracted = GCPAuditLog.extract(log_message)
+    assert len(extracted.resources) == expected_resource_count
+
+
+@pytest.mark.parametrize(
+    'filename,expected_disk_names', [
+        ('compute_instance_creation_logs_1.json', ['console-devicenames', 'disk2name']),
+        ('compute_instance_creation_logs_2.json', []),
+        ('compute_instance_creation_logs_3.json', ['console-nochange']),
+        ('compute_instance_creation_logs_4.json', ['gcloud-devicename-mismatch']),
+        ('compute_instance_creation_logs_5.json', ['demo-testing-good-boot', 'demo-testing-good-data']),
+    ]
+)
+def test_compute_instance_logs_get_disk_names(filename, expected_disk_names):
+    '''
+        Instance creation audit logs contain details about the disks, but extracting the disk name is
+        complicated. This tests multiple known log formats for instance creation against expected disk names.
+    '''
+
+    log = get_test_data(filename)
+
+    extracted = GCPAuditLog.extract(log)
+
+    disk_names = [
+        resource.resource_name for resource in extracted.resources if resource.type() == GcpComputeDisk.resource_type
+    ]
+    assert sorted(disk_names) == sorted(expected_disk_names)
+
+
+def test_invalid_audit_log():
+    with pytest.raises(ExtractorException):
+        extracted = GCPAuditLog.extract({})


### PR DESCRIPTION
Moving over the parser from real-time-enforcer, but making it fit better wtih rpelib. Rather than log parsers, I'm introducing the idea of resource extractors, which extract resource objects from structured data. This includes support for additional metadata from the structured data.

Basically the same logic from real-time-enforcer, but more resource-centric.