### PR TITLE
Add inferred data support

### DIFF
--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -43,8 +43,6 @@ class GoogleAPIResource(Resource):
     # Other properties of a resource we might need to perform evaluations, such as iam policy
     resource_components = {}
 
-    uniquifier_path = None
-
     # If a resource is not in a ready state, we can't update it. If we retrieve
     # it, and the state changes, updates will be rejected because the ETAG will
     # have changed. If a resource defines readiness criteria, the get() call
@@ -458,11 +456,9 @@ class GoogleAPIResource(Resource):
     # creation timestamp of the resource. Not all resources have fields that make this  possible.
     @property
     def uniquifier(self):
-        if not self.uniquifier_path:
-            return None
+        self._refresh_inferred_data()
 
-        resource_metadata = self.get(refresh=False).get("resource")
-        return jmespath.search(self.uniquifier_path, resource_metadata)
+        return self._resource_data.get("uniquifier")
 
 
 class GcpAppEngineInstance(GoogleAPIResource):
@@ -477,7 +473,9 @@ class GcpAppEngineInstance(GoogleAPIResource):
 
     required_resource_data = ["name", "app", "service", "version"]
 
-    uniquifier_path = "startTime"
+    inferred_data_map = {
+        "uniquifier": "startTime",
+    }
 
     def _get_request_args(self):
         return {
@@ -498,7 +496,9 @@ class GcpBigqueryDataset(GoogleAPIResource):
 
     resource_type = "bigquery.googleapis.com/Dataset"
 
-    uniquifier_path = "id"
+    inferred_data_map = {
+        "uniquifier": "id",
+    }
 
     def _get_request_args(self):
         return {
@@ -589,7 +589,9 @@ class GcpComputeInstance(GoogleAPIResource):
 
     resource_type = "compute.googleapis.com/Instance"
 
-    uniquifier_path = "id"
+    inferred_data_map = {
+        "uniquifier": "id",
+    }
 
     def _get_request_args(self):
         return {
@@ -609,7 +611,9 @@ class GcpComputeDisk(GoogleAPIResource):
 
     resource_type = "compute.googleapis.com/Disk"
 
-    uniquifier_path = "id"
+    inferred_data_map = {
+        "uniquifier": "id",
+    }
 
     def _get_request_args(self):
         return {
@@ -629,7 +633,9 @@ class GcpComputeRegionDisk(GoogleAPIResource):
 
     resource_type = "compute.googleapis.com/RegionDisk"
 
-    uniquifier_path = "id"
+    inferred_data_map = {
+        "uniquifier": "id",
+    }
 
     def _get_request_args(self):
         return {
@@ -649,7 +655,9 @@ class GcpComputeNetwork(GoogleAPIResource):
 
     resource_type = "compute.googleapis.com/Network"
 
-    uniquifier_path = "id"
+    inferred_data_map = {
+        "uniquifier": "id",
+    }
 
     def _get_request_args(self):
         return {
@@ -668,7 +676,9 @@ class GcpComputeSubnetwork(GoogleAPIResource):
 
     resource_type = "compute.googleapis.com/Subnetwork"
 
-    uniquifier_path = "id"
+    inferred_data_map = {
+        "uniquifier": "id",
+    }
 
     def _get_request_args(self):
         return {
@@ -688,7 +698,9 @@ class GcpComputeFirewall(GoogleAPIResource):
 
     resource_type = "compute.googleapis.com/Firewall"
 
-    uniquifier_path = "id"
+    inferred_data_map = {
+        "uniquifier": "id",
+    }
 
     def _get_request_args(self):
         return {
@@ -706,7 +718,9 @@ class GcpDataprocCluster(GoogleAPIResource):
 
     resource_type = "dataproc.googleapis.com/Cluster"
 
-    uniquifier_path = "clusterUuid"
+    inferred_data_map = {
+        "uniquifier": "clusterUuid",
+    }
 
     def _get_request_args(self):
         return {
@@ -733,7 +747,9 @@ class GcpDatafusionInstance(GoogleAPIResource):
 
     resource_type = "datafusion.googleapis.com/Instance"
 
-    uniquifier_path = "createTime"
+    inferred_data_map = {
+        "uniquifier": "createTime",
+    }
 
     def _get_request_args(self):
         return {
@@ -769,7 +785,9 @@ class GcpGkeCluster(GoogleAPIResource):
 
     resource_type = "container.googleapis.com/Cluster"
 
-    uniquifier_path = "id"
+    inferred_data_map = {
+        "uniquifier": "id",
+    }
 
     def _get_request_args(self):
         return {
@@ -820,7 +838,9 @@ class GcpIamServiceAccount(GoogleAPIResource):
 
     resource_type = "iam.googleapis.com/ServiceAccount"
 
-    uniquifier_path = "uniqueId"
+    inferred_data_map = {
+        "uniquifier": "uniqueId",
+    }
 
     def _get_request_args(self):
         return {
@@ -840,7 +860,9 @@ class GcpIamServiceAccountKey(GoogleAPIResource):
 
     resource_type = "iam.googleapis.com/ServiceAccountKey"
 
-    uniquifier_path = "privateKeyData"
+    inferred_data_map = {
+        "uniquifier": "privateKeyData",
+    }
 
     def _get_request_args(self):
         return {
@@ -924,10 +946,9 @@ class GcpStorageBucket(GoogleAPIResource):
 
     resource_type = "storage.googleapis.com/Bucket"
 
-    uniquifier_path = "timeCreated"
-
     inferred_data_map = {
         "location": "location",
+        "uniquifier": "timeCreated",
     }
 
     def _get_request_args(self):
@@ -987,7 +1008,9 @@ class GcpProject(GoogleAPIResource):
 
     resource_type = "cloudresourcemanager.googleapis.com/Project"  # beta
 
-    uniquifier_path = "projectNumber"
+    inferred_data_map = {
+        "uniquifier": "projectNumber",
+    }
 
     def _get_request_args(self):
         return {"projectId": self._resource_data["name"]}
@@ -1024,7 +1047,9 @@ class GcpDataflowJob(GoogleAPIResource):
 
     resource_type = "dataflow.googleapis.com/Job"
 
-    uniquifier_path = "id"
+    inferred_data_map = {
+        "uniquifier": "id",
+    }
 
     def _get_request_args(self):
         return {
@@ -1049,7 +1074,9 @@ class GcpRedisInstance(GoogleAPIResource):
 
     resource_type = "redis.googleapis.com/Instance"
 
-    uniquifier_path = "createTime"
+    inferred_data_map = {
+        "uniquifier": "createTime",
+    }
 
     def _get_request_args(self):
         return {
@@ -1075,7 +1102,9 @@ class GcpMemcacheInstance(GoogleAPIResource):
 
     resource_type = "memcache.googleapis.com/Instance"
 
-    uniquifier_path = "createTime"
+    inferred_data_map = {
+        "uniquifier": "createTime",
+    }
 
     def _get_request_args(self):
         return {

--- a/tests/test_gcp_resource_inferred_data.py
+++ b/tests/test_gcp_resource_inferred_data.py
@@ -1,0 +1,81 @@
+from rpe.resources.gcp import GoogleAPIResource
+from googleapiclient.http import HttpMockSequence
+import pytest
+
+
+@pytest.mark.parametrize(
+    "name,asset_type,http,inferred_key",
+    [
+        pytest.param(
+            "//storage.googleapis.com/buckets/test-bucket",
+            "storage.googleapis.com/Bucket",
+            HttpMockSequence(
+                [
+                    ({"status": 200}, '{"location": "US"}'),
+                    ({"status": 200}, '{"iam_policy":""}'),
+                ]
+            ),
+            "location",
+            id="bucket_location",
+        ),
+        pytest.param(
+            "//compute.googleapis.com/projects/test-project/zones/test-zone/instances/test-instance",
+            "compute.googleapis.com/Instance",
+            HttpMockSequence(
+                [
+                    ({"status": 200}, '{"id": "1234567890"}'),
+                    ({"status": 200}, '{"iam_policy":""}'),
+                ]
+            ),
+            "uniquifier",
+            id="instance_uniquifier",
+        ),
+    ],
+)
+def test_inferred_data_lookup_success(name, asset_type, http, inferred_key):
+    res = GoogleAPIResource.from_cai_data(name, asset_type, http=http)
+
+    assert inferred_key not in res._resource_data
+    res.to_dict()
+    assert inferred_key in res._resource_data
+
+
+@pytest.mark.parametrize(
+    "name,asset_type,http",
+    [
+        pytest.param(
+            "//storage.googleapis.com/buckets/test-bucket",
+            "storage.googleapis.com/Bucket",
+            HttpMockSequence(
+                [
+                    ({"status": 401}, '{"msg": "oops"}'),
+                ]
+            ),
+            id="resource_401",
+        ),
+        pytest.param(
+            "//compute.googleapis.com/projects/test-project/zones/test-zone/instances/test-instance",
+            "compute.googleapis.com/Instance",
+            HttpMockSequence(
+                [
+                    ({"status": 404}, '{"msg": "something went wrong"}'),
+                ]
+            ),
+            id="resource_404",
+        ),
+        pytest.param(
+            "//compute.googleapis.com/projects/test-project/zones/test-zone/instances/test-instance",
+            "compute.googleapis.com/Instance",
+            HttpMockSequence(
+                [
+                    ({"status": 200}, "HTTP ERROR: NOT JSON"),
+                ]
+            ),
+            id="malformed_json",
+        ),
+    ],
+)
+def test_todict_eats_exceptions(name, asset_type, http):
+    res = GoogleAPIResource.from_cai_data(name, asset_type, http=http)
+
+    res.to_dict()


### PR DESCRIPTION
For `GoogleAPIResource`s, the `resource_data` attribute represents he data used to identify the resource in GCP. It typically includes the following attributes: `project_id`, `name`, `location`. Some resources require additional attributes, for example a _GKE Nodepool_ also needs the name of the cluster.

Most of these attributes are also part of the resource's `full_resource_name` so we populate them when instantiating the `GoogleAPIResource` object.

`GCPStorageBucket`s, however, do not include their `location` in the `full_resource_name`. To support retrieving a bucket's location, this PR adds support for `resource_data` that must be inferred from the contents of the resource's `metadata` (the API representation of the resource). When calling the `to_dict()` function, we attempt to populate any inferred data into the `resource_data` attribute, which is then included in the function's return value.

This PR also recognizes that the `uniquifier` property we recently added also fits pretty well into this implementation, so to simplify the structure of `GoogleAPIResource`s, this PR merges that implementation with this one.