### PR TITLE
Properly set the project_id for a project resource

### DIFF
--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -92,7 +92,7 @@ class GoogleAPIResource(Resource):
 
         # Most resources need only a subset of these fields to query the google apis
         fields = {
-            "project_id": r"/projects/([^\/]+)/",
+            "project_id": r"/projects/([^\/]+)(/.*)?$",
             "location": r"/(?:locations|regions|zones)/([^\/]+)/",
             "name": r"([^\/]+)$",
             # Less-common resource data


### PR DESCRIPTION
For GcpProject resources the project_id is not set, because the regex only sets the project_id if theres a trailing slash. This allows trailing slash or end-of-line