### PR TITLE
support conditional python policy evaluation.

### DIFF
--- a/rpe/engines/python.py
+++ b/rpe/engines/python.py
@@ -83,6 +83,13 @@ class PythonPolicyEngine:
 
         for policy_name, policy_cls in matched_policies.items():
             try:
+                if hasattr(policy_cls, "should_evaluate_policy"):
+                    should_evaluate_policy_res = policy_cls.should_evaluate_policy(resource)
+                    if not should_evaluate_policy_res:
+                        print(f"Policy: {policy_name}, will not be evaluated for resource {resource} "
+                              f"as should_evaluate_policy returned {should_evaluate_policy_res}")
+                        continue
+
                 if hasattr(policy_cls, "evaluate"):
                     eval_result = policy_cls.evaluate(resource)
                     if not isinstance(eval_result, EvaluationResult):

--- a/rpe/engines/python.py
+++ b/rpe/engines/python.py
@@ -84,10 +84,14 @@ class PythonPolicyEngine:
         for policy_name, policy_cls in matched_policies.items():
             try:
                 if hasattr(policy_cls, "should_evaluate_policy"):
-                    should_evaluate_policy_res = policy_cls.should_evaluate_policy(resource)
+                    should_evaluate_policy_res = policy_cls.should_evaluate_policy(
+                        resource
+                    )
                     if not should_evaluate_policy_res:
-                        print(f"Policy: {policy_name}, will not be evaluated for resource {resource} "
-                              f"as should_evaluate_policy returned {should_evaluate_policy_res}")
+                        print(
+                            f"Policy: {policy_name}, will not be evaluated for resource {resource} "
+                            f"as should_evaluate_policy returned {should_evaluate_policy_res}"
+                        )
                         continue
 
                 if hasattr(policy_cls, "evaluate"):


### PR DESCRIPTION
Description: if a python policy implements should_evaluate_policy method, it can choose to have it evaluate a resource if the method returns True or ignore to be part of policy engine evaluation chain if the method returns False. Default behavior is still to be part of evaluation engine chain always.